### PR TITLE
Reduce logic cells needed for EC TickTimer

### DIFF
--- a/betrusted_ec.py
+++ b/betrusted_ec.py
@@ -614,7 +614,7 @@ class BaseSoC(SoCCore):
         self.add_interrupt("i2c")
 
         # High-resolution tick timer ---------------------------------------------------------------------
-        self.submodules.ticktimer = TickTimer(1000, clk_freq, bits=40)
+        self.submodules.ticktimer = TickTimer(1000, clk_freq, bits=32)
         self.add_csr("ticktimer")
         self.add_interrupt("ticktimer")
 

--- a/betrusted_ec.py
+++ b/betrusted_ec.py
@@ -614,7 +614,7 @@ class BaseSoC(SoCCore):
         self.add_interrupt("i2c")
 
         # High-resolution tick timer ---------------------------------------------------------------------
-        self.submodules.ticktimer = TickTimer(1000, clk_freq, bits=32)
+        self.submodules.ticktimer = TickTimer(1000, clk_freq, bits=30)
         self.add_csr("ticktimer")
         self.add_interrupt("ticktimer")
 


### PR DESCRIPTION
This saves about 140 logic cells at the expense of shortening the TickTimer overflow period. Unsure about correctness of overflow behavior.

Making this change allows the EC gateware to successfully build with `fomu-toolchain-linux_x86_64-v1.5.6` (current latest). Otherwise, the build dies with an error because it tries to use 5314 logic cells (limit is 5280).

I've tested the smaller ticktimer counter only by way of running `python3 betrusted_ec.py --revision=pvt`, so I'm not sure how it would behave on hardware. Also, by my reading of the rust code dealing with ticktimer in the EC firmware, it's possible that the high 8 bits of the 40 bit timer count were already being ignored. Perhaps this will behave just like the 40 bit counter, including potentially troublesome overflow behavior?

The logic cell savings vary as a function of the counter size:

| TickTimer(..., bits=n) | ICESTORM_LC | Logic Cell Diff | Overflow Period |
|-|-|-|-|
| 40 bits | 5314 | 0 | 12725 days |
| 32 bits | 5270 | -44 | 49 days |
| 31 bits | 5215 | -99 | 24 days |
| 30 bits | 5172 | -142 | 12 days |

Overflow period formula for `n` bit counter at 1 ms clock:
`period = 2^n / 1000 (ms/s) / 60 (s/min) / 60 (min/hour) / 24 (hour/day)`

Partial results of running `betrusted_ec.py` for TickTimer with bits=30:

```
Info: Device utilisation:
Info: 	         ICESTORM_LC:  5172/ 5280    97%
Info: 	        ICESTORM_RAM:    16/   30    53%
Info: 	               SB_IO:    36/   96    37%
Info: 	               SB_GB:     8/    8   100%
Info: 	        ICESTORM_PLL:     1/    1   100%
Info: 	         SB_WARMBOOT:     0/    1     0%
Info: 	        ICESTORM_DSP:     0/    8     0%
Info: 	      ICESTORM_HFOSC:     0/    1     0%
Info: 	      ICESTORM_LFOSC:     0/    1     0%
Info: 	              SB_I2C:     1/    2    50%
Info: 	              SB_SPI:     0/    2     0%
Info: 	              IO_I3C:     0/    2     0%
Info: 	         SB_LEDDA_IP:     0/    1     0%
Info: 	         SB_RGBA_DRV:     0/    1     0%
Info: 	      ICESTORM_SPRAM:     4/    4   100%
```

Also, either I've been doing a sloppy job of copying numbers between windows (possible) or the ICESTORM_LC values seem to jump around a bit unpredictably, perhaps related to switching git branches or interrupting yosys with `^C`. The numbers I get for logic cells used seem to be sometimes repeatable, and sometimes not.