### PR TITLE
Add TX buffer flow control to EC serial debug

### DIFF
--- a/sw/betrusted-hal/src/debug.rs
+++ b/sw/betrusted-hal/src/debug.rs
@@ -1,23 +1,78 @@
+//! Serial debug for wishbone-bridge crossover UART.
+//!
+//! To enable serial debug printing:
+//!  1. Build and flash EC gateware with `debugonly = True`
+//!  2. In ../Cargo.toml, enable the "debug_uart" feature for this crate
+//!
+
 #[cfg(feature = "debug_uart")]
 use utralib::generated::*;
 
-pub struct Uart {
-}
+use crate::hal_time::delay_ms;
+
+/// The flow control timeout determines how long putc() waits to decide if the
+/// wishbone-bridge connection is down before dropping characters.
+///
+const FLOW_CONTROL_TIMEOUT_MS: usize = 1000;
+
+pub struct Uart {}
 
 #[cfg(feature = "debug_uart")]
 impl Uart {
+    /// Write to UART with TX buffer flow control to allow for intermittent
+    /// wishbone-bridge connection.
+    ///
+    /// Goal of flow control strategy is to provide non-blocking IO with
+    /// timeout limited CSR polling in order to:
+    ///  1. Avoid DoS of wishbone bus
+    ///  2. Avoid starving main control loop and COM handlers for CPU cycles
+    ///
+    /// The tradeoff for control loop responsiveness is that some debug
+    /// characters may be dropped. Timeout delay is calibrated so that, when a
+    /// wishbone-tool serial connection is established promptly after reset,
+    /// dropped characters are unlikely.
+    ///
     pub fn putc(&self, c: u8) {
+        static mut MUTED: bool = false;
         let mut uart_csr = CSR::new(HW_UART_BASE as *mut u32);
-        // Wait until TXFULL is `0`
-        while uart_csr.rf(utra::uart::TXFULL_TXFULL) != 0 {}
-        uart_csr.wfo(utra::uart::RXTX_RXTX, c as u32)
+        let tx_buffer_empty = uart_csr.rf(utra::uart::TXEMPTY_TXEMPTY) == 1;
+        if unsafe { MUTED } && !tx_buffer_empty {
+            // Looks like connection is still down... Drop this character.
+            return;
+        } else if tx_buffer_empty {
+            // Yay... looks like wishbone-bridge connection is back!
+            unsafe {
+                MUTED = false;
+            }
+        } else {
+            if uart_csr.rf(utra::uart::TXFULL_TXFULL) == 1 {
+                // Hmm... TX buffer is newly full... Watch to see if it drains...
+                for _ in 0..FLOW_CONTROL_TIMEOUT_MS {
+                    delay_ms(1);
+                    if uart_csr.rf(utra::uart::TXFULL_TXFULL) == 0 {
+                        break;
+                    }
+                }
+                if uart_csr.rf(utra::uart::TXFULL_TXFULL) == 1 {
+                    // Boo... Nope. Looks like the connection just dropped...
+                    // 1. Mute to avoid pointlessly calling delay_ms() while there is
+                    //    no active wishbone-bridge connection to drain the TX buffer
+                    // 2. Begin dropping characters, starting with this one
+                    unsafe {
+                        MUTED = true;
+                    }
+                    return;
+                }
+            }
+        }
+        // Since the flow control checks all passed, send a character
+        uart_csr.wfo(utra::uart::RXTX_RXTX, c as u32);
     }
 }
 
 #[cfg(not(feature = "debug_uart"))]
 impl Uart {
-    pub fn putc(&self, _c: u8) {
-    }
+    pub fn putc(&self, _c: u8) {}
 }
 
 use core::fmt::{Error, Write};
@@ -39,6 +94,10 @@ macro_rules! sprint
 	});
 }
 
+// Note to people tempted to change "\r\n" to "\n" in the macros below:
+// Wishbone-tool's serial bridge expects CRLF style line termination. If you do
+// LF only, it will print your text in diagonal cascades instead of columns.
+//
 #[macro_export]
 macro_rules! sprintln
 {
@@ -52,4 +111,3 @@ macro_rules! sprintln
 		sprint!(concat!($fmt, "\r\n"), $($args)+)
 	});
 }
-

--- a/sw/src/debug.rs
+++ b/sw/src/debug.rs
@@ -1,31 +1,78 @@
+//! Serial debug for wishbone-bridge crossover UART.
+//!
+//! To enable serial debug printing:
+//!  1. Build and flash EC gateware with `debugonly = True`
+//!  2. In ../Cargo.toml, enable the "debug_uart" feature for this crate
+//!
+
 #[cfg(feature = "debug_uart")]
-use betrusted_hal::hal_time::delay_ms;
 use utralib::generated::*;
 
-pub struct Uart {
-}
+use betrusted_hal::hal_time::delay_ms;
+
+/// The flow control timeout determines how long putc() waits to decide if the
+/// wishbone-bridge connection is down before dropping characters.
+///
+const FLOW_CONTROL_TIMEOUT_MS: usize = 1000;
+
+pub struct Uart {}
 
 #[cfg(feature = "debug_uart")]
 impl Uart {
+    /// Write to UART with TX buffer flow control to allow for intermittent
+    /// wishbone-bridge connection.
+    ///
+    /// Goal of flow control strategy is to provide non-blocking IO with
+    /// timeout limited CSR polling in order to:
+    ///  1. Avoid DoS of wishbone bus
+    ///  2. Avoid starving main control loop and COM handlers for CPU cycles
+    ///
+    /// The tradeoff for control loop responsiveness is that some debug
+    /// characters may be dropped. Timeout delay is calibrated so that, when a
+    /// wishbone-tool serial connection is established promptly after reset,
+    /// dropped characters are unlikely.
+    ///
     pub fn putc(&self, c: u8) {
+        static mut MUTED: bool = false;
         let mut uart_csr = CSR::new(HW_UART_BASE as *mut u32);
-        if uart_csr.rf(utra::uart::TXFULL_TXFULL) == 1 {
-            // If nobody has connected `wishbone-tool ... -s terminal ...` to
-            // the debug UART, TXFULL will get stuck at 1. Also possible for
-            // connection to be okay but debug prints happening too quickly.
-            delay_ms(10);
+        let tx_buffer_empty = uart_csr.rf(utra::uart::TXEMPTY_TXEMPTY) == 1;
+        if unsafe { MUTED } && !tx_buffer_empty {
+            // Looks like connection is still down... Drop this character.
+            return;
+        } else if tx_buffer_empty {
+            // Yay... looks like wishbone-bridge connection is back!
+            unsafe {
+                MUTED = false;
+            }
+        } else {
+            if uart_csr.rf(utra::uart::TXFULL_TXFULL) == 1 {
+                // Hmm... TX buffer is newly full... Watch to see if it drains...
+                for _ in 0..FLOW_CONTROL_TIMEOUT_MS {
+                    delay_ms(1);
+                    if uart_csr.rf(utra::uart::TXFULL_TXFULL) == 0 {
+                        break;
+                    }
+                }
+                if uart_csr.rf(utra::uart::TXFULL_TXFULL) == 1 {
+                    // Boo... Nope. Looks like the connection just dropped...
+                    // 1. Mute to avoid pointlessly calling delay_ms() while there is
+                    //    no active wishbone-bridge connection to drain the TX buffer
+                    // 2. Begin dropping characters, starting with this one
+                    unsafe {
+                        MUTED = true;
+                    }
+                    return;
+                }
+            }
         }
-        // Caution! This silently drops a character if TX buffer is still full
-        if uart_csr.rf(utra::uart::TXFULL_TXFULL) == 0 {
-            uart_csr.wfo(utra::uart::RXTX_RXTX, c as u32);
-        }
+        // Since the flow control checks all passed, send a character
+        uart_csr.wfo(utra::uart::RXTX_RXTX, c as u32);
     }
 }
 
 #[cfg(not(feature = "debug_uart"))]
 impl Uart {
-    pub fn putc(&self, _c: u8) {
-    }
+    pub fn putc(&self, _c: u8) {}
 }
 
 use core::fmt::{Error, Write};
@@ -47,6 +94,10 @@ macro_rules! sprint
 	});
 }
 
+// Note to people tempted to change "\r\n" to "\n" in the macros below:
+// Wishbone-tool's serial bridge expects CRLF style line termination. If you do
+// LF only, it will print your text in diagonal cascades instead of columns.
+//
 #[macro_export]
 macro_rules! sprintln
 {
@@ -60,4 +111,3 @@ macro_rules! sprintln
 		sprint!(concat!($fmt, "\r\n"), $($args)+)
 	});
 }
-

--- a/sw/src/main.rs
+++ b/sw/src/main.rs
@@ -145,43 +145,7 @@ fn com_rx(timeout: u32) -> Result<u16, &'static str> {
     Ok(unsafe{ (*com_rd).read() as u16 })
 }
 
-static mut LL_DEBUG_MUTED: bool = true;
-
-fn ll_debug_mute() {
-    unsafe { LL_DEBUG_MUTED = true; }
-}
-
-fn ll_debug_unmute() {
-    unsafe { LL_DEBUG_MUTED = false; }
-}
-
 fn ll_debug(msg: &str) {
-    let uart_csr = utralib::generated::CSR::new(HW_UART_BASE as *mut u32);
-    // Anticipate intermittent wishbone-bridge crossover UART connection
-    // (perhaps interupted by keyboard scan)
-    if unsafe{ LL_DEBUG_MUTED } {
-        if uart_csr.rf(utra::uart::TXEMPTY_TXEMPTY) == 1 {
-            // Yay... looks like wishbone-bridge connection is back up!
-            ll_debug_unmute();
-        } else {
-            return;
-        }
-    } else {
-        if uart_csr.rf(utra::uart::TXFULL_TXFULL) == 1 {
-            // Hmm... TX buffer is backed up, so watch to see if it drains...
-            for _ in 0..10 {
-                delay_ms(5);
-                if uart_csr.rf(utra::uart::TXFULL_TXFULL) == 0 {
-                    break;
-                }
-            }
-            if uart_csr.rf(utra::uart::TXFULL_TXFULL) == 1 {
-                // Boo... Nope. Looks like the wishbone-bridge connection is down.
-                ll_debug_mute();
-                return;
-            }
-        }
-    }
     if cfg!(feature = "debug_uart") && true { // extra boolean for finer-grained control of debug spew
         sprintln!("{}", msg);
         // delay_ms(50);
@@ -190,23 +154,10 @@ fn ll_debug(msg: &str) {
 
 #[entry]
 fn main() -> ! {
-    let uart_csr = utralib::generated::CSR::new(HW_UART_BASE as *mut u32);
     /* loop {  // a tiny sanity check stub
         (debug::Uart {}).putc('a' as u8);
     } */
-    ll_debug_unmute();
-    ll_debug("Hello world!");
-    // Check to see if the initial message gets removed from the TX buffer
-    // within a reasonble timeout. Use that as a heuristic to decide whether
-    // any further debug messages should be printed to the UART.
-    ll_debug_mute();
-    for _ in 0..20 {
-        delay_ms(5);
-        if uart_csr.rf(utra::uart::TXEMPTY_TXEMPTY) == 1 {
-            ll_debug_unmute();
-            break;
-        }
-    }
+    ll_debug("\r\n====UP5K====");
     let mut power_csr = CSR::new(HW_POWER_BASE as *mut u32);
     let mut com_csr = CSR::new(HW_COM_BASE as *mut u32);
     let mut crg_csr = CSR::new(HW_CRG_BASE as *mut u32);


### PR DESCRIPTION
This PR aims to make serial debug connections with wishbone-tool more stable by adding flow control.

Functional Changes:
1. Debug `putc` now uses hysteresis check of TXFULL and TXEMPTY UART CSRs as a flow control heuristic to guess when a wishbone-bridge serial tunnel is connected. When the TX buffer fills up and wishbone-bridge connection is down, `putc` first waits for a re-connect, then either resumes TX or begins dropping characters if the timeout expires.
2. Serial TX now avoids rapid polling of the wishbone bus. Reducing wishbone bus activity seems to make wishbone-tool connections more reliable and the firmware generally more stable.
3. EC initial boot string of "Hello world!" is now "\r\n====UP5K====" so resets will be more visually obvious in the wishbone-tool serial console log.

Flow control strategy:
1. When the TX buffer becomes full, wait up to 1000ms for at least one character to be drained over the wishbone-bridge.
2. If the timeout expires with TX buffer still full, begin dropping all new characters until the TX buffer is empty.
3. Once the TX buffer is empty, reset the 1000ms timer and resume adding characters to the TX buffer again.

The intended effect is that `putc()` will block for up to 1 second after reset, or when the wishbone-tool connection is interrupted. But, after that timeout expires, control flow will run at full speed until wishbone-tool connects and drains the TX buffer.

Usage:
Using serial debug reliably requires building the gateware with `debugonly = True` in `betrusted_ec.py`. But, with this change, the EC still gives an intermittent wishbone-tool link when the gateware is built with `debugonly = False`. In that case, some of the serial debug characters get lost, but the connection partially works.

Duplicate Code:
I don't know why the pre-existing `sw/betrusted-hal/src/debug.rs` and `sw/src/debug.rs` files were duplicates. But, this commit updates both of them with duplicate copies of the new flow control code.

Probably the duplicates should be consolidated, but to keep things simple, I'm not going to worry about that now.

Related Issue:
[EC firmware contains many unbounded while...{} loops that could block the control loop #3](https://github.com/betrusted-io/betrusted-ec/issues/3 )