### PR TITLE
Refactor to prepare for adding more WF200 wifi networking support

### DIFF
--- a/sw/src/com_bus.rs
+++ b/sw/src/com_bus.rs
@@ -1,0 +1,36 @@
+use betrusted_hal::hal_time::get_time_ms;
+use utralib::generated::{utra, CSR, HW_COM_BASE};
+use volatile::Volatile;
+
+pub fn com_int_handler(_irq_no: usize) {
+    let mut com_csr = CSR::new(HW_COM_BASE as *mut u32);
+    // nop handler, here just to wake up the CPU in case of an incoming SPI packet and run the normal loop
+    com_csr.wfo(utra::com::EV_PENDING_SPI_AVAIL, 1);
+}
+
+pub fn com_tx(tx: u16) {
+    let com_ptr: *mut u32 = utralib::HW_COM_MEM as *mut u32;
+    let com_fifo = com_ptr as *mut Volatile<u32>;
+
+    unsafe {
+        (*com_fifo).write(tx as u32);
+    }
+}
+
+pub fn com_rx(timeout: u32) -> Result<u16, &'static str> {
+    let com_csr = CSR::new(HW_COM_BASE as *mut u32);
+    let com_rd_ptr: *mut u32 = utralib::HW_COM_MEM as *mut u32;
+    let com_rd = com_rd_ptr as *mut Volatile<u32>;
+
+    if timeout != 0 && (com_csr.rf(utra::com::STATUS_RX_AVAIL) == 0) {
+        let start = get_time_ms();
+        loop {
+            if com_csr.rf(utra::com::STATUS_RX_AVAIL) == 1 {
+                break;
+            } else if start + timeout < get_time_ms() {
+                return Err("timeout");
+            }
+        }
+    }
+    Ok(unsafe { (*com_rd).read() as u16 })
+}

--- a/sw/src/dead_code.rs
+++ b/sw/src/dead_code.rs
@@ -1,0 +1,52 @@
+//! This file is for dead code that was hanging around in main.rs. I'm putting
+//! it here so it's out of the way. To see how it used to be, look for commits
+//! from before July 2021.
+use utralib::generated::HW_SPIFLASH_MEM;
+
+#[allow(dead_code)] // used for debugging
+pub fn dump_rom_addr(addr: u32) {
+    let rom_ptr: *mut u32 = (addr + HW_SPIFLASH_MEM as u32) as *mut u32;
+    let rom = rom_ptr as *mut Volatile<u32>;
+    for i in 0..64 {
+        if i % 8 == 0 {
+            sprint!("\n\r0x{:06x}: ", addr + i * 4);
+        }
+        let data: u32 = unsafe { (*rom.add(i as usize)).read() };
+        sprint!(
+            "{:02x} {:02x} {:02x} {:02x} ",
+            data & 0xFF,
+            (data >> 8) & 0xff,
+            (data >> 16) & 0xff,
+            (data >> 24) & 0xff
+        );
+    }
+    sprintln!("");
+}
+
+pub fn cut_from_main() {
+    /*
+    // check that the gas gauge capacity is correct; if not, reset it
+    if gg_set_design_capacity(&mut i2c, None) != 1100 {
+        gg_set_design_capacity(&mut i2c, Some(1100));
+    } */
+    // seems to work better with the default 1340mAh capacity even though that's not our actual capacity
+
+    /*  // kept around as a quick test routine for SPI flashing
+        let mut idcode: [u8; 3] = [0; 3];
+        spi_cmd(CMD_RDID, None, Some(&mut idcode));
+        sprintln!("SPI ID code: {:02x} {:02x} {:02x}", idcode[0], idcode[1], idcode[2]);
+        let test_addr = 0x8_0000;
+        dump_rom_addr(test_addr);
+        spi_erase_region(test_addr, 4096);
+
+        dump_rom_addr(test_addr);
+
+        let mut test_data: [u8; 256] = [0; 256];
+        for i in 0..256 {
+            test_data[i] = (255 - i) as u8;
+        }
+        spi_program_page(test_addr, &mut test_data);
+
+        dump_rom_addr(test_addr);
+    */
+}

--- a/sw/src/debug.rs
+++ b/sw/src/debug.rs
@@ -8,12 +8,32 @@
 #[cfg(feature = "debug_uart")]
 use utralib::generated::*;
 
+#[cfg(feature = "debug_uart")]
 use betrusted_hal::hal_time::delay_ms;
 
 /// The flow control timeout determines how long putc() waits to decide if the
 /// wishbone-bridge connection is down before dropping characters.
-///
+#[cfg(feature = "debug_uart")]
 const FLOW_CONTROL_TIMEOUT_MS: usize = 1000;
+
+#[derive(PartialOrd, PartialEq)]
+#[allow(dead_code)]
+pub enum LL {
+    Trace = 0,
+    Debug = 1,
+    Info = 2,
+    Warn = 3,
+    Error = 4,
+    Fatal = 5,
+}
+
+static mut LOG_LEVEL: LL = LL::Info;
+
+pub fn set_log_level(level: LL) {
+    unsafe {
+        LOG_LEVEL = level;
+    }
+}
 
 pub struct Uart {}
 
@@ -85,7 +105,6 @@ impl Write for Uart {
     }
 }
 
-#[macro_export]
 macro_rules! sprint
 {
 	($($args:tt)+) => ({
@@ -98,7 +117,6 @@ macro_rules! sprint
 // Wishbone-tool's serial bridge expects CRLF style line termination. If you do
 // LF only, it will print your text in diagonal cascades instead of columns.
 //
-#[macro_export]
 macro_rules! sprintln
 {
 	() => ({
@@ -110,4 +128,32 @@ macro_rules! sprintln
 	($fmt:expr, $($args:tt)+) => ({
 		sprint!(concat!($fmt, "\r\n"), $($args)+)
 	});
+}
+
+#[cfg(feature = "debug_uart")]
+macro_rules! log {
+    ($level:expr, $($e:expr),+) => {
+        if LOG_LEVEL <= $level {
+            sprint!($($e),+)
+        }
+    }
+}
+
+#[cfg(feature = "debug_uart")]
+macro_rules! logln {
+    ($level:expr, $($e:expr),*) => {
+        if LOG_LEVEL <= $level {
+            sprintln!($($e),*)
+        }
+    }
+}
+
+#[cfg(not(feature = "debug_uart"))]
+macro_rules! log {
+    ($_a:expr, $($_b:expr),+) => {()};
+}
+
+#[cfg(not(feature = "debug_uart"))]
+macro_rules! logln {
+    ($($_a:expr),+) => {()};
 }

--- a/sw/src/main.rs
+++ b/sw/src/main.rs
@@ -12,15 +12,13 @@ extern crate volatile;
 
 use betrusted_hal::api_bq25618::BtCharger;
 use betrusted_hal::api_gasgauge::{
-    gg_avg_current, gg_full_capacity, gg_remaining_capacity, gg_set_design_capacity,
-    gg_set_hibernate, gg_start, gg_state_of_charge, gg_voltage,
+    gg_full_capacity, gg_remaining_capacity, gg_set_design_capacity, gg_set_hibernate, gg_start,
+    gg_state_of_charge,
 };
 use betrusted_hal::api_lm3509::BtBacklight;
 use betrusted_hal::api_tusb320::BtUsbCc;
 use betrusted_hal::hal_hardi2c::Hardi2c;
-use betrusted_hal::hal_time::{
-    delay_ms, get_time_ms, get_time_ticks, set_msleep_target_ticks, time_init,
-};
+use betrusted_hal::hal_time::{delay_ms, get_time_ms, set_msleep_target_ticks, time_init};
 
 extern crate wfx_bindings;
 extern crate wfx_rs;
@@ -50,13 +48,13 @@ use volatile::Volatile;
 #[macro_use]
 mod debug;
 
+mod power_mgmt;
+use power_mgmt::charger_handler;
+
 mod spi;
 use spi::{spi_erase_region, spi_program_page, spi_standby};
 extern crate com_rs;
 use com_rs::ComState;
-
-const BATTERY_PANIC_VOLTAGE: i16 = 3500; // this is the voltage that we hard shut down the device to avoid battery damage
-const BATTERY_LOW_VOLTAGE: i16 = 3575; // this is the reserve voltage where we attempt to shut off the SoC so that BBRAM keys, RTC are preserved
 
 const CONFIG_CLOCK_FREQUENCY: u32 = 18_000_000;
 
@@ -174,8 +172,8 @@ fn main() -> ! {
     /* loop {  // a tiny sanity check stub
         (debug::Uart {}).putc('a' as u8);
     } */
-    ll_debug("\r\n====UP5K====");
-    let mut power_csr = CSR::new(HW_POWER_BASE as *mut u32);
+    ll_debug("\r\n====UP5K==00");
+    let mut power_csr: CSR<u32> = CSR::new(HW_POWER_BASE as *mut u32);
     let mut com_csr = CSR::new(HW_COM_BASE as *mut u32);
     let mut crg_csr = CSR::new(HW_CRG_BASE as *mut u32);
     let mut ticktimer_csr = CSR::new(HW_TICKTIMER_BASE as *mut u32);
@@ -348,100 +346,23 @@ fn main() -> ! {
             //////////////////////// ---------------------------
 
             //////////////////////// CHARGER HANDLER BLOCK -----
-            // I2C can't happen inside an interrupt routine, so we do it in the main loop
-            // real time response is also not critical; note this runs "lazily", only if the COM loop is idle
-            if get_time_ms() - last_run_time > 1000 {
-                last_run_time = get_time_ms();
-                loopcounter += 1;
-
-                // routine pings & housekeeping; split i2c traffic across two phases to even the CPU load
-                if loopcounter % 2 == 0 {
-                    charger.chg_keepalive_ping(&mut i2c);
-                    if !usb_cc_event {
-                        usb_cc_event = usb_cc.check_event(&mut i2c);
-                        if usb_cc.status[1] & 0xC0 == 0x80 {
-                            // Attached.SNK transition
-                            charger.chg_start(&mut i2c);
-                        }
-                    }
-                } else {
-                    voltage = gg_voltage(&mut i2c);
-                    if voltage < 0 {
-                        // there are monitoring glitches during charge mode transitions, try to catch and filter them out
-                        voltage = last_voltage;
-                        voltage_glitch = true;
-                    }
-                    last_voltage = voltage;
-                    if voltage < BATTERY_PANIC_VOLTAGE {
-                        let cursoc = gg_state_of_charge(&mut i2c);
-                        if cursoc < 5 && battery_panic {
-                            // in case of a cold boot, give the charger a few seconds to recognize charging and raise the voltage
-                            // also don't attempt to go shipmode if the charger is indicating it is trying to charge
-                            if get_time_ticks() > 8000
-                                && !charger.chg_is_charging(&mut i2c, false)
-                                && gg_voltage(&mut i2c) < BATTERY_PANIC_VOLTAGE
-                            {
-                                // put the device into "shipmode" which disconnects the battery from the system
-                                // NOTE: this may cause the loss of volatile keys
-                                backlight.set_brightness(&mut i2c, 0, 0); // make sure the backlight is off
-
-                                charger.set_shipmode(&mut i2c);
-                                gg_set_hibernate(&mut i2c);
-                                let power = power_csr.ms(utra::power::POWER_SELF, 1)
-                                    | power_csr.ms(utra::power::POWER_DISCHARGE, 1);
-                                power_csr.wo(utra::power::POWER, power);
-                                set_msleep_target_ticks(500);
-                                delay_ms(16_000); // 15s max time for ship mode to kick in, add 1s just to be safe
-                            }
-                        } else if cursoc < 5 {
-                            // require a second check before shutting things down, to rule out temporary glitches in measurement
-                            battery_panic = true;
-                        }
-                    } else if voltage < BATTERY_LOW_VOLTAGE {
-                        // TODO: warn the SoC that power is about to go away using the COM_IRQ feature...
-                        // siginficantly: shutting down the SoC without its consent is not possible.
-                        // so this needs to be refactored once Xous gets to a state where it can handle a power state request
-                        // for now just make a NOP
-
-                        // NOTE: this should probably get more aggressive about shutting down wifi, etc.
-                        /*
-                        if gg_state_of_charge(&mut i2c) < 10 {
-                            backlight.set_brightness(&mut i2c, 0, 0); // make sure the backlight is off
-                            let power =
-                            power_csr.ms(utra::power::POWER_SELF, 1)
-                            | power_csr.ms(utra::power::POWER_DISCHARGE, 1);
-                            power_csr.wo(utra::power::POWER, power);
-
-                            set_msleep_target_ticks(500); // extend next service so we can discharge
-
-                            pd_loop_timer = get_time_ms();
-                        }
-                        */
-                    } else {
-                        battery_panic = false;
-                    }
-                    if power_csr.rf(utra::power::STATS_STATE) == 1 {
-                        current = gg_avg_current(&mut i2c);
-                    } else if power_csr.rf(utra::power::STATS_STATE) == 0 && !soc_was_on {
-                        // only sample if the last state was also powered off, so we aren't averaging in ~1s worth of "power on" current while this loop triggers
-                        stby_current = gg_avg_current(&mut i2c);
-                    }
-                    if power_csr.rf(utra::power::STATS_STATE) == 1 {
-                        soc_was_on = true;
-                    } else {
-                        soc_was_on = false;
-                    }
-                }
-
-                // check if we should turn the SoC on or not based on power status change events
-                if charger.chg_is_charging(&mut i2c, false) {
-                    // sprintln!("charger insert or soc on event!");
-                    let power = power_csr.ms(utra::power::POWER_SELF, 1)
-                        | power_csr.ms(utra::power::POWER_SOC_ON, 1)
-                        | power_csr.ms(utra::power::POWER_DISCHARGE, 0);
-                    power_csr.wo(utra::power::POWER, power); // turn off discharge if the soc is up
-                }
-            }
+            charger_handler(
+                &mut power_csr,
+                &mut charger,
+                &mut i2c,
+                &mut last_run_time,
+                &mut loopcounter,
+                &mut voltage,
+                &mut last_voltage,
+                &mut current,
+                &mut stby_current,
+                &mut soc_was_on,
+                &mut battery_panic,
+                &mut voltage_glitch,
+                &mut usb_cc_event,
+                &mut usb_cc,
+                &mut backlight,
+            );
             //////////////////////// ---------------------------
         }
 

--- a/sw/src/main.rs
+++ b/sw/src/main.rs
@@ -26,8 +26,8 @@ use core::panic::PanicInfo;
 use gyro_rs::hal_gyro::BtGyro;
 use riscv_rt::entry;
 use utralib::generated::{
-    utra, CSR, HW_COM_BASE, HW_CRG_BASE, HW_GIT_BASE, HW_POWER_BASE, HW_SPIFLASH_MEM,
-    HW_TICKTIMER_BASE, HW_WIFI_BASE,
+    utra, CSR, HW_COM_BASE, HW_CRG_BASE, HW_GIT_BASE, HW_POWER_BASE, HW_TICKTIMER_BASE,
+    HW_WIFI_BASE,
 };
 use volatile::Volatile;
 use wfx_bindings::SL_STATUS_OK;
@@ -97,26 +97,6 @@ fn ticktimer_int_handler(_irq_no: usize) {
     set_msleep_target_ticks(50); // resetting this will also clear the alarm
 
     ticktimer_csr.wfo(utra::ticktimer::EV_PENDING_ALARM, 1);
-}
-
-#[allow(dead_code)] // used for debugging
-fn dump_rom_addr(addr: u32) {
-    let rom_ptr: *mut u32 = (addr + HW_SPIFLASH_MEM as u32) as *mut u32;
-    let rom = rom_ptr as *mut Volatile<u32>;
-    for i in 0..64 {
-        if i % 8 == 0 {
-            sprint!("\n\r0x{:06x}: ", addr + i * 4);
-        }
-        let data: u32 = unsafe { (*rom.add(i as usize)).read() };
-        sprint!(
-            "{:02x} {:02x} {:02x} {:02x} ",
-            data & 0xFF,
-            (data >> 8) & 0xff,
-            (data >> 16) & 0xff,
-            (data >> 24) & 0xff
-        );
-    }
-    sprintln!("");
 }
 
 fn ll_debug(msg: &str) {
@@ -208,31 +188,6 @@ fn main() -> ! {
     hw.charger.update_regs(&mut i2c);
     ll_debug("charger.update_regs");
 
-    /*
-    // check that the gas gauge capacity is correct; if not, reset it
-    if gg_set_design_capacity(&mut i2c, None) != 1100 {
-        gg_set_design_capacity(&mut i2c, Some(1100));
-    } */
-    // seems to work better with the default 1340mAh capacity even though that's not our actual capacity
-
-    /*  // kept around as a quick test routine for SPI flashing
-        let mut idcode: [u8; 3] = [0; 3];
-        spi_cmd(CMD_RDID, None, Some(&mut idcode));
-        sprintln!("SPI ID code: {:02x} {:02x} {:02x}", idcode[0], idcode[1], idcode[2]);
-        let test_addr = 0x8_0000;
-        dump_rom_addr(test_addr);
-        spi_erase_region(test_addr, 4096);
-
-        dump_rom_addr(test_addr);
-
-        let mut test_data: [u8; 256] = [0; 256];
-        for i in 0..256 {
-            test_data[i] = (255 - i) as u8;
-        }
-        spi_program_page(test_addr, &mut test_data);
-
-        dump_rom_addr(test_addr);
-    */
     spi_standby(); // make sure the OE's are off, no spurious power consumption
     ll_debug("spi_standby");
 
@@ -451,7 +406,8 @@ fn main() -> ! {
             } else if rx >= ComState::BL_START.verb && rx <= ComState::BL_END.verb {
                 let main_bl_level: u8 = (rx & 0x1F) as u8;
                 let sec_bl_level: u8 = ((rx >> 5) & 0x1F) as u8;
-                hw.backlight.set_brightness(&mut i2c, main_bl_level, sec_bl_level);
+                hw.backlight
+                    .set_brightness(&mut i2c, main_bl_level, sec_bl_level);
             } else if rx == ComState::LINK_READ.verb {
                 // this a "read continuation" command, in other words, return read data
                 // based on the current ComState

--- a/sw/src/power_mgmt.rs
+++ b/sw/src/power_mgmt.rs
@@ -1,0 +1,159 @@
+extern crate betrusted_hal;
+extern crate utralib;
+extern crate volatile;
+use betrusted_hal::api_bq25618::BtCharger;
+use betrusted_hal::api_gasgauge::{
+    gg_avg_current, gg_set_hibernate, gg_state_of_charge, gg_voltage,
+};
+use betrusted_hal::api_lm3509::BtBacklight;
+use betrusted_hal::api_tusb320::BtUsbCc;
+use betrusted_hal::hal_hardi2c::Hardi2c;
+use betrusted_hal::hal_time::{delay_ms, get_time_ms, get_time_ticks, set_msleep_target_ticks};
+use utralib::generated::{utra, CSR};
+
+// This is the voltage that we hard shut down the device to avoid battery damage
+const BATTERY_PANIC_VOLTAGE: i16 = 3500;
+
+// This is the reserve voltage where we attempt to shut off the SoC so that BBRAM keys, RTC are preserved
+const BATTERY_LOW_VOLTAGE: i16 = 3575;
+
+// == 2021-07-14 REFACTOR IN PROGRESS =========================================
+// TODO: Fix the comments and argument passing of charger_handler().
+//
+// This is mostly a copy & paste from the event loop in main.rs::main(). The
+// exceptions are reduced indentation and dereferencing of mutable reference
+// arguments. For now, there are various things about comments and code in
+// charger_handler() that don't make sense when removed from the context of
+// main(). I'm trying to avoid changing too much at once so it's easier to read
+// through the commit history and review the changes step by step.
+// ============================================================================
+
+/// This function wraps a tricky chunk of I2C driver code that manages battery
+/// and power subsystem stuff, including:
+/// - Activating ship-mode
+/// - USB-C charge cable detection
+/// - Battery voltage and state of charge
+/// - Adjusting battery charge current
+/// - Low voltage panic shutdown
+///
+/// DANGER! DANGER! Be careful about changing this code. The EC's I2C interface
+/// uses the SB_I2C hard IP block on the Lattice iCE40 UP5K. SB_I2C is
+/// generally a bit weird and also very picky about timing. Also, this code is
+/// important for safe shipping and overall battery health.
+///
+pub fn charger_handler(
+    power_csr: &mut CSR<u32>,
+    charger: &mut BtCharger,
+    mut i2c: &mut Hardi2c,
+    last_run_time: &mut u32,
+    loopcounter: &mut u32,
+    voltage: &mut i16,
+    last_voltage: &mut i16,
+    current: &mut i16,
+    stby_current: &mut i16,
+    soc_was_on: &mut bool,
+    battery_panic: &mut bool,
+    voltage_glitch: &mut bool,
+    usb_cc_event: &mut bool,
+    usb_cc: &mut BtUsbCc,
+    backlight: &mut BtBacklight,
+) {
+    // I2C can't happen inside an interrupt routine, so we do it in the main loop
+    // real time response is also not critical; note this runs "lazily", only if the COM loop is idle
+    if get_time_ms() - *last_run_time > 1000 {
+        *last_run_time = get_time_ms();
+        *loopcounter += 1;
+
+        // routine pings & housekeeping; split i2c traffic across two phases to even the CPU load
+        if *loopcounter % 2 == 0 {
+            charger.chg_keepalive_ping(&mut i2c);
+            if !(*usb_cc_event) {
+                *usb_cc_event = usb_cc.check_event(&mut i2c);
+                if usb_cc.status[1] & 0xC0 == 0x80 {
+                    // Attached.SNK transition
+                    charger.chg_start(&mut i2c);
+                }
+            }
+        } else {
+            *voltage = gg_voltage(&mut i2c);
+            if *voltage < 0 {
+                // there are monitoring glitches during charge mode transitions, try to catch and
+                // filter them out
+                *voltage = *last_voltage;
+                *voltage_glitch = true;
+            }
+            *last_voltage = *voltage;
+            if *voltage < BATTERY_PANIC_VOLTAGE {
+                let cursoc = gg_state_of_charge(&mut i2c);
+                if cursoc < 5 && *battery_panic {
+                    // in case of a cold boot, give the charger a few seconds to recognize charging
+                    // and raise the voltage also don't attempt to go shipmode if the charger is
+                    // indicating it is trying to charge
+                    if get_time_ticks() > 8000
+                        && !charger.chg_is_charging(&mut i2c, false)
+                        && gg_voltage(&mut i2c) < BATTERY_PANIC_VOLTAGE
+                    {
+                        // put the device into "shipmode" which disconnects the battery from the system
+                        // NOTE: this may cause the loss of volatile keys
+                        backlight.set_brightness(&mut i2c, 0, 0); // make sure the backlight is off
+
+                        charger.set_shipmode(&mut i2c);
+                        gg_set_hibernate(&mut i2c);
+                        let power = power_csr.ms(utra::power::POWER_SELF, 1)
+                            | power_csr.ms(utra::power::POWER_DISCHARGE, 1);
+                        power_csr.wo(utra::power::POWER, power);
+                        set_msleep_target_ticks(500);
+                        delay_ms(16_000); // 15s max time for ship mode to kick in, add 1s just to be safe
+                    }
+                } else if cursoc < 5 {
+                    // require a second check before shutting things down, to rule out temporary
+                    // glitches in measurement
+                    *battery_panic = true;
+                }
+            } else if *voltage < BATTERY_LOW_VOLTAGE {
+                // TODO: warn the SoC that power is about to go away using the COM_IRQ feature...
+                // siginficantly: shutting down the SoC without its consent is not possible. so this
+                // needs to be refactored once Xous gets to a state where it can handle a power
+                // state request for now just make a NOP
+
+                // NOTE: this should probably get more aggressive about shutting down wifi, etc.
+                /*
+                if gg_state_of_charge(&mut i2c) < 10 {
+                    backlight.set_brightness(&mut i2c, 0, 0); // make sure the backlight is off
+                    let power =
+                    power_csr.ms(utra::power::POWER_SELF, 1)
+                    | power_csr.ms(utra::power::POWER_DISCHARGE, 1);
+                    power_csr.wo(utra::power::POWER, power);
+
+                    set_msleep_target_ticks(500); // extend next service so we can discharge
+
+                    pd_loop_timer = get_time_ms();
+                }
+                */
+            } else {
+                *battery_panic = false;
+            }
+            if power_csr.rf(utra::power::STATS_STATE) == 1 {
+                *current = gg_avg_current(&mut i2c);
+            } else if power_csr.rf(utra::power::STATS_STATE) == 0 && !(*soc_was_on) {
+                // only sample if the last state was also powered off, so we aren't averaging in ~1s
+                // worth of "power on" current while this loop triggers
+                *stby_current = gg_avg_current(&mut i2c);
+            }
+            if power_csr.rf(utra::power::STATS_STATE) == 1 {
+                *soc_was_on = true;
+            } else {
+                *soc_was_on = false;
+            }
+        }
+
+        // check if we should turn the SoC on or not based on power status change events
+        if charger.chg_is_charging(&mut i2c, false) {
+            // sprintln!("charger insert or soc on event!");
+            let power = power_csr.ms(utra::power::POWER_SELF, 1)
+                | power_csr.ms(utra::power::POWER_SOC_ON, 1)
+                | power_csr.ms(utra::power::POWER_DISCHARGE, 0);
+            power_csr.wo(utra::power::POWER, power); // turn off discharge if the soc is up
+        }
+    }
+}

--- a/sw/src/wifi.rs
+++ b/sw/src/wifi.rs
@@ -2,9 +2,9 @@ use betrusted_hal::hal_time::delay_ms;
 use utralib::generated::{utra, CSR, HW_WIFI_BASE};
 use wfx_bindings::SL_STATUS_OK;
 use wfx_rs::hal_wf200::{
-    wf200_fw_build, wf200_fw_major, wf200_fw_minor, wf200_get_rx_stats_raw, wf200_send_pds,
-    wf200_ssid_get_list, wf200_ssid_updated, wfx_drain_event_queue, wfx_handle_event, wfx_init,
-    wfx_start_scan,
+    wf200_fw_build, wf200_fw_major, wf200_fw_minor, wf200_send_pds, wf200_ssid_get_list,
+    wfx_drain_event_queue, wfx_handle_event, wfx_init, wfx_start_scan,
+    wfx_ssid_scan_in_progress,
 };
 
 pub const SSID_ARRAY_SIZE: usize = wfx_rs::hal_wf200::SSID_ARRAY_SIZE;
@@ -62,14 +62,12 @@ pub fn start_scan() {
     //    point, the scan is done and you can start another one if you want.
     //
     let limit = 32;
-    sprintln!("draining WF200 event queue...");
     wfx_drain_event_queue(limit);
-    sprintln!("starting scan...");
     wfx_start_scan();
 }
 
-pub fn ssid_updated() -> bool {
-    wf200_ssid_updated()
+pub fn ssid_scan_in_progress() -> bool {
+    wfx_ssid_scan_in_progress()
 }
 
 pub fn ssid_get_list(mut ssid_list: &mut [[u8; 32]; SSID_ARRAY_SIZE]) {
@@ -86,10 +84,6 @@ pub fn fw_major() -> u8 {
 
 pub fn fw_minor() -> u8 {
     wf200_fw_minor()
-}
-
-pub fn get_rx_stats_raw() -> [u8; 376] {
-    wf200_get_rx_stats_raw()
 }
 
 pub fn send_pds(data: [u8; 256], length: u16) -> bool {

--- a/sw/src/wifi.rs
+++ b/sw/src/wifi.rs
@@ -1,15 +1,13 @@
-use betrusted_hal::hal_time::{delay_ms, get_time_ms, set_msleep_target_ticks, time_init};
-use utralib::generated::{
-    utra, CSR, HW_COM_BASE, HW_CRG_BASE, HW_GIT_BASE, HW_POWER_BASE, HW_SPIFLASH_MEM,
-    HW_TICKTIMER_BASE, HW_WIFI_BASE,
-};
+use betrusted_hal::hal_time::delay_ms;
+use utralib::generated::{utra, CSR, HW_WIFI_BASE};
 use wfx_bindings::SL_STATUS_OK;
 use wfx_rs::hal_wf200::{
-    wf200_fw_build, wf200_fw_major, wf200_fw_minor, wf200_get_rx_stats_raw, wf200_mutex_get,
-    wf200_send_pds, wf200_ssid_get_list, wf200_ssid_updated, wfx_handle_event, wfx_init,
-    wfx_scan_ongoing, wfx_start_scan,
+    wf200_fw_build, wf200_fw_major, wf200_fw_minor, wf200_get_rx_stats_raw, wf200_send_pds,
+    wf200_ssid_get_list, wf200_ssid_updated, wfx_drain_event_queue, wfx_handle_event, wfx_init,
+    wfx_start_scan,
 };
 
+pub const SSID_ARRAY_SIZE: usize = wfx_rs::hal_wf200::SSID_ARRAY_SIZE;
 
 pub fn wf200_reset_momentary() {
     let mut wifi_csr = CSR::new(HW_WIFI_BASE as *mut u32);
@@ -33,11 +31,71 @@ pub fn wf200_init() -> bool {
 }
 
 pub fn wf200_irq_disable() {
-    let mut wifi_csr = CSR::new(HW_WIFI_BASE as *mut u32);
-    wifi_csr.wfo(utra::wifi::EV_ENABLE_WIRQ, 0);
+    //let mut wifi_csr = CSR::new(HW_WIFI_BASE as *mut u32);
+    //wifi_csr.wfo(utra::wifi::EV_ENABLE_WIRQ, 0);
 }
 
 pub fn wf200_irq_enable() {
-    let mut wifi_csr = CSR::new(HW_WIFI_BASE as *mut u32);
-    wifi_csr.wfo(utra::wifi::EV_ENABLE_WIRQ, 1);
+    //let mut wifi_csr = CSR::new(HW_WIFI_BASE as *mut u32);
+    //wifi_csr.wfo(utra::wifi::EV_ENABLE_WIRQ, 1);
+}
+
+pub fn start_scan() {
+    // This call initiates an aysnc scan that takes about 800ms in active scan
+    // mode or about 1500ms in passive scan mode. The scan is a one-shot thing
+    // that ends automatically. You can start another scan once the first one
+    // ends.
+    //
+    // Precautions (see samblenny/wfx_docs):
+    // 1. Scanning seems to work better if, before starting a scan, you drain
+    //    the WF200 received frames queue by calling sl_wfx_receive_frame()
+    //    until it stops returning SL_STATUS_OK
+    // 2. Starting a second scan before getting a SL_WFX_SCAN_COMPLETE_IND_ID
+    //    is not good idea.
+    //
+    // Assuming you set up a control loop task to poll the WF200 WIRQ output
+    // and call sl_wfx_receive_frame() when it's asserted, scan results will
+    // appear as arguments to sl_wfx_host_post_event():
+    // 1. Each new SSID gets posted as an event with event payload header ID of
+    //    SL_WFX_SCAN_RESULT_IND_ID
+    // 2. Post of SL_WFX_SCAN_COMPLETE_IND_ID event marks end of scan. At that
+    //    point, the scan is done and you can start another one if you want.
+    //
+    let limit = 32;
+    sprintln!("draining WF200 event queue...");
+    wfx_drain_event_queue(limit);
+    sprintln!("starting scan...");
+    wfx_start_scan();
+}
+
+pub fn ssid_updated() -> bool {
+    wf200_ssid_updated()
+}
+
+pub fn ssid_get_list(mut ssid_list: &mut [[u8; 32]; SSID_ARRAY_SIZE]) {
+    wf200_ssid_get_list(&mut ssid_list);
+}
+
+pub fn fw_build() -> u8 {
+    wf200_fw_build()
+}
+
+pub fn fw_major() -> u8 {
+    wf200_fw_major()
+}
+
+pub fn fw_minor() -> u8 {
+    wf200_fw_minor()
+}
+
+pub fn get_rx_stats_raw() -> [u8; 376] {
+    wf200_get_rx_stats_raw()
+}
+
+pub fn send_pds(data: [u8; 256], length: u16) -> bool {
+    wf200_send_pds(data, length)
+}
+
+pub fn handle_event() -> u32 {
+    wfx_handle_event()
 }

--- a/sw/src/wifi.rs
+++ b/sw/src/wifi.rs
@@ -1,0 +1,43 @@
+use betrusted_hal::hal_time::{delay_ms, get_time_ms, set_msleep_target_ticks, time_init};
+use utralib::generated::{
+    utra, CSR, HW_COM_BASE, HW_CRG_BASE, HW_GIT_BASE, HW_POWER_BASE, HW_SPIFLASH_MEM,
+    HW_TICKTIMER_BASE, HW_WIFI_BASE,
+};
+use wfx_bindings::SL_STATUS_OK;
+use wfx_rs::hal_wf200::{
+    wf200_fw_build, wf200_fw_major, wf200_fw_minor, wf200_get_rx_stats_raw, wf200_mutex_get,
+    wf200_send_pds, wf200_ssid_get_list, wf200_ssid_updated, wfx_handle_event, wfx_init,
+    wfx_scan_ongoing, wfx_start_scan,
+};
+
+
+pub fn wf200_reset_momentary() {
+    let mut wifi_csr = CSR::new(HW_WIFI_BASE as *mut u32);
+    wifi_csr.rmwf(utra::wifi::WIFI_RESET, 1);
+    delay_ms(10);
+    wifi_csr.rmwf(utra::wifi::WIFI_RESET, 0);
+    delay_ms(10);
+}
+
+pub fn wf200_reset_hold() {
+    let mut wifi_csr = CSR::new(HW_WIFI_BASE as *mut u32);
+    wifi_csr.rmwf(utra::wifi::WIFI_RESET, 1);
+}
+
+/// Initialize the WF200, returning of true means success
+pub fn wf200_init() -> bool {
+    match wfx_init() {
+        SL_STATUS_OK => true,
+        _ => false,
+    }
+}
+
+pub fn wf200_irq_disable() {
+    let mut wifi_csr = CSR::new(HW_WIFI_BASE as *mut u32);
+    wifi_csr.wfo(utra::wifi::EV_ENABLE_WIRQ, 0);
+}
+
+pub fn wf200_irq_enable() {
+    let mut wifi_csr = CSR::new(HW_WIFI_BASE as *mut u32);
+    wifi_csr.wfo(utra::wifi::EV_ENABLE_WIRQ, 1);
+}

--- a/sw/wfx_rs/src/hal_wf200.rs
+++ b/sw/wfx_rs/src/hal_wf200.rs
@@ -914,7 +914,7 @@ fn sl_wfx_scan_result_callback(scan_result: *const sl_wfx_scan_result_ind_body_t
     let ssid = unsafe { str::from_utf8(slice::from_raw_parts(&(*scan_result).ssid_def.ssid as *const u8, 32)).expect("unable to parse ssid") };
     unsafe { // because raw pointer dereferences
         sprintln!("scan-- ch:{} str:-{} mac:{:02x}{:02x}{:02x}{:02x}{:02x}{:02x} ssid:{}",
-            (*scan_result).channel,
+            core::ptr::addr_of!((*scan_result).channel).read_unaligned(),
             32768 - (((*scan_result).rcpi - 220) / 2),
             (*scan_result).mac[0], (*scan_result).mac[1],
             (*scan_result).mac[2], (*scan_result).mac[3],
@@ -1040,7 +1040,12 @@ pub unsafe extern "C" fn sl_wfx_host_post_event(event_payload: *mut sl_wfx_gener
                     RX_STATS_RAW = (*generic_indication).body.indication_data;
                 }
             } else {
-                if DEBUGGING { sprintln!("SL_WFX_GENERIC_IND_ID type {}, attempting to dispach", (*generic_indication).body.indication_type); }
+                if DEBUGGING {
+                    sprintln!(
+                        "SL_WFX_GENERIC_IND_ID type {}, attempting to dispach",
+                        core::ptr::addr_of!((*generic_indication).body.indication_type).read_unaligned()
+                    );
+                }
                 if (*generic_indication).body.indication_type == sl_wfx_generic_indication_type_e_SL_WFX_GENERIC_INDICATION_TYPE_STRING {
                     let dbgstr = (*generic_indication).body.indication_data.raw_data;
                     if DEBUGGING {
@@ -1068,7 +1073,10 @@ pub unsafe extern "C" fn sl_wfx_host_post_event(event_payload: *mut sl_wfx_gener
         sl_wfx_general_indications_ids_e_SL_WFX_ERROR_IND_ID => {
             sprintln!("Firmware error");
             let firmware_error: *const sl_wfx_error_ind_t = event_payload as *const sl_wfx_error_ind_t;
-            sprintln!("Error type = {}", (*firmware_error).body.type_);
+            sprintln!(
+                "Error type = {}",
+                core::ptr::addr_of!((*firmware_error).body.type_).read_unaligned()
+            );
         },
         sl_wfx_general_indications_ids_e_SL_WFX_STARTUP_IND_ID => {
             sprintln!("wf200 started!");

--- a/sw/wfx_rs/src/hal_wf200.rs
+++ b/sw/wfx_rs/src/hal_wf200.rs
@@ -5,13 +5,7 @@ use crate::betrusted_hal::hal_time::get_time_ms;
 use crate::wfx_bindings;
 use core::slice;
 use core::str;
-
 use utralib::generated::{utra, CSR, HW_WIFI_BASE};
-
-pub const DEBUGGING: bool = false; //true;
-pub const DEBUG_SPI: bool = false;
-pub const DEBUGGING2: bool = false; //true;  // more verbose debugging
-pub const DEBUG_MALLOC: bool = false;
 
 #[macro_use]
 mod debug;
@@ -19,33 +13,39 @@ mod debug;
 mod bt_wf200_pds;
 use bt_wf200_pds::PDS_DATA;
 
+// The mixed case constants here are the reason for the `allow(nonstandard_style)` above
 pub use wfx_bindings::{
-    sl_status_t, SL_STATUS_OK, sl_wfx_error_ind_t, SL_WFX_EXCEPTION_DATA_SIZE,
-    sl_wfx_exception_ind_t, sl_wfx_generic_ind_t, sl_wfx_generic_indication_type_e_SL_WFX_GENERIC_INDICATION_TYPE_RX_STATS,
-    sl_wfx_generic_indication_type_e_SL_WFX_GENERIC_INDICATION_TYPE_STRING, sl_wfx_scan_complete_ind_t,
-    sl_wfx_scan_result_ind_t, sl_wfx_received_ind_t, sl_wfx_start_ap_ind_t, sl_wfx_disconnect_ind_t,
-    sl_wfx_connect_ind_t, sl_wfx_generic_message_t, sl_wfx_receive_frame, sl_wfx_ssid_def_t,
-    sl_wfx_scan_mode_e_WFM_SCAN_MODE_ACTIVE, sl_wfx_send_scan_command, sl_wfx_scan_result_ind_body_t,
-    sl_wfx_enable_device_power_save, sl_wfx_pm_mode_e_WFM_PM_MODE_PS, sl_wfx_set_power_mode,
-    sl_wfx_state_t_SL_WFX_STA_INTERFACE_CONNECTED, sl_wfx_state_t_SL_WFX_AP_INTERFACE_UP,
-    sl_wfx_disable_device_power_save, sl_wfx_pm_mode_e_WFM_PM_MODE_ACTIVE, SL_STATUS_WIFI_SLEEP_GRANTED,
-    sl_wfx_register_address_t, sl_wfx_host_bus_transfer_type_t, sl_wfx_data_write, SL_STATUS_IO_TIMEOUT,
-    SL_WFX_CONT_NEXT_LEN_MASK, sl_wfx_mac_address_t, sl_wfx_context_t, SL_STATUS_ALLOCATION_FAILED,
-    sl_wfx_buffer_type_t, sl_wfx_host_bus_transfer_type_t_SL_WFX_BUS_READ, sl_wfx_init, u_int32_t,
-    sl_wfx_send_configuration, sl_wfx_rx_stats_s, sl_wfx_indication_data_u,
-    sl_wfx_fmac_status_e_WFM_STATUS_SUCCESS, sl_wfx_fmac_status_e_WFM_STATUS_NO_MATCHING_AP,
-    sl_wfx_fmac_status_e_WFM_STATUS_CONNECTION_ABORTED, sl_wfx_fmac_status_e_WFM_STATUS_CONNECTION_TIMEOUT,
-    sl_wfx_fmac_status_e_WFM_STATUS_CONNECTION_REJECTED_BY_AP, sl_wfx_fmac_status_e_WFM_STATUS_CONNECTION_AUTH_FAILURE,
-    sl_wfx_indications_ids_e_SL_WFX_DISCONNECT_IND_ID, sl_wfx_indications_ids_e_SL_WFX_START_AP_IND_ID,
-    sl_wfx_indications_ids_e_SL_WFX_STOP_AP_IND_ID, sl_wfx_indications_ids_e_SL_WFX_RECEIVED_IND_ID,
-    sl_wfx_indications_ids_e_SL_WFX_SCAN_RESULT_IND_ID, sl_wfx_indications_ids_e_SL_WFX_SCAN_COMPLETE_IND_ID,
-    sl_wfx_indications_ids_e_SL_WFX_AP_CLIENT_DISCONNECTED_IND_ID,
-    sl_wfx_general_indications_ids_e_SL_WFX_GENERIC_IND_ID, sl_wfx_confirmations_ids_e_SL_WFX_STOP_SCAN_CNF_ID,
-    sl_wfx_indications_ids_e_SL_WFX_AP_CLIENT_CONNECTED_IND_ID, sl_wfx_confirmations_ids_e_SL_WFX_START_SCAN_CNF_ID,
-    sl_wfx_indications_ids_e_SL_WFX_AP_CLIENT_REJECTED_IND_ID, sl_wfx_general_indications_ids_e_SL_WFX_ERROR_IND_ID,
-    sl_wfx_general_indications_ids_e_SL_WFX_EXCEPTION_IND_ID,
-    sl_wfx_indications_ids_e_SL_WFX_CONNECT_IND_ID, sl_wfx_general_indications_ids_e_SL_WFX_STARTUP_IND_ID,
+    sl_status_t, sl_wfx_buffer_type_t, sl_wfx_confirmations_ids_e_SL_WFX_START_SCAN_CNF_ID,
+    sl_wfx_confirmations_ids_e_SL_WFX_STOP_SCAN_CNF_ID, sl_wfx_connect_ind_t, sl_wfx_context_t,
+    sl_wfx_data_write, sl_wfx_disable_device_power_save, sl_wfx_disconnect_ind_t,
+    sl_wfx_enable_device_power_save, sl_wfx_error_ind_t, sl_wfx_exception_ind_t,
+    sl_wfx_fmac_status_e_WFM_STATUS_CONNECTION_ABORTED,
+    sl_wfx_fmac_status_e_WFM_STATUS_CONNECTION_AUTH_FAILURE,
+    sl_wfx_fmac_status_e_WFM_STATUS_CONNECTION_REJECTED_BY_AP,
+    sl_wfx_fmac_status_e_WFM_STATUS_CONNECTION_TIMEOUT,
+    sl_wfx_fmac_status_e_WFM_STATUS_NO_MATCHING_AP, sl_wfx_fmac_status_e_WFM_STATUS_SUCCESS,
     sl_wfx_general_confirmations_ids_e_SL_WFX_CONFIGURATION_CNF_ID,
+    sl_wfx_general_indications_ids_e_SL_WFX_ERROR_IND_ID,
+    sl_wfx_general_indications_ids_e_SL_WFX_EXCEPTION_IND_ID,
+    sl_wfx_general_indications_ids_e_SL_WFX_GENERIC_IND_ID,
+    sl_wfx_general_indications_ids_e_SL_WFX_STARTUP_IND_ID, sl_wfx_generic_ind_t,
+    sl_wfx_generic_indication_type_e_SL_WFX_GENERIC_INDICATION_TYPE_RX_STATS,
+    sl_wfx_generic_indication_type_e_SL_WFX_GENERIC_INDICATION_TYPE_STRING,
+    sl_wfx_generic_message_t, sl_wfx_host_bus_transfer_type_t,
+    sl_wfx_host_bus_transfer_type_t_SL_WFX_BUS_READ, sl_wfx_indication_data_u,
+    sl_wfx_indications_ids_e_SL_WFX_CONNECT_IND_ID,
+    sl_wfx_indications_ids_e_SL_WFX_DISCONNECT_IND_ID,
+    sl_wfx_indications_ids_e_SL_WFX_RECEIVED_IND_ID,
+    sl_wfx_indications_ids_e_SL_WFX_SCAN_COMPLETE_IND_ID,
+    sl_wfx_indications_ids_e_SL_WFX_SCAN_RESULT_IND_ID, sl_wfx_init, sl_wfx_mac_address_t,
+    sl_wfx_pm_mode_e_WFM_PM_MODE_ACTIVE, sl_wfx_pm_mode_e_WFM_PM_MODE_PS, sl_wfx_receive_frame,
+    sl_wfx_received_ind_t, sl_wfx_register_address_t, sl_wfx_rx_stats_s,
+    sl_wfx_scan_complete_ind_t, sl_wfx_scan_mode_e_WFM_SCAN_MODE_ACTIVE,
+    sl_wfx_scan_result_ind_body_t, sl_wfx_scan_result_ind_t, sl_wfx_send_configuration,
+    sl_wfx_send_scan_command, sl_wfx_set_power_mode, sl_wfx_ssid_def_t,
+    sl_wfx_state_t_SL_WFX_STA_INTERFACE_CONNECTED, u_int32_t, SL_STATUS_ALLOCATION_FAILED,
+    SL_STATUS_IO_TIMEOUT, SL_STATUS_OK, SL_STATUS_WIFI_SLEEP_GRANTED, SL_WFX_CONT_NEXT_LEN_MASK,
+    SL_WFX_EXCEPTION_DATA_SIZE,
 };
 // This is defined in wfx-fullMAC-driver/wfx_fmac_driver/firmware/sl_wfx_general_error_api.h in the enum
 // typedef for sl_wfx_error_t. For some reason that I don't care to hunt down at the moment, this is not
@@ -55,19 +55,22 @@ const SL_WFX_HIF_BUS_ERROR: u32 = 0xf;
 pub const WIFI_EVENT_WIRQ: u32 = 0x1;
 
 // locate firmware at SPI top minus 400kiB. Datasheet says reserve at least 350kiB for firmwares.
-pub const WFX_FIRMWARE_OFFSET: usize = 0x2000_0000 + 1024*1024 - 400*1024; // 0x2009_C000
+pub const WFX_FIRMWARE_OFFSET: usize = 0x2000_0000 + 1024 * 1024 - 400 * 1024; // 0x2009_C000
+
 //pub const WFX_FIRMWARE_SIZE: usize = 290896; // version C0, as burned to ROM v3.3.2
 pub const WFX_FIRMWARE_SIZE: usize = 305232; // version C0, as burned to ROM v3.12.1
 
 /// make a very shitty, temporary malloc that can hold up to 16 entries in the 32k space
 /// this is all to avoid including the "alloc" crate, which is "nightly" and not "stable"
 // reserve top 32kiB for WFX FFI RAM buffers
-pub const WFX_RAM_LENGTH: usize = 32*1024;
-pub const WFX_RAM_OFFSET: usize = 0x1000_0000 + 128*1024 - WFX_RAM_LENGTH; // 1001_8000
+pub const WFX_RAM_LENGTH: usize = 32 * 1024;
+pub const WFX_RAM_OFFSET: usize = 0x1000_0000 + 128 * 1024 - WFX_RAM_LENGTH; // 1001_8000
 static mut WFX_RAM_ALLOC: usize = WFX_RAM_OFFSET;
 pub const WFX_MAX_PTRS: usize = 8;
 static mut WFX_PTR_COUNT: u8 = 0;
 static mut WFX_PTR_LIST: [usize; WFX_MAX_PTRS] = [0; WFX_MAX_PTRS];
+
+static mut SSID_SCAN_IN_PROGRESS: bool = false;
 
 #[derive(Copy, Clone)]
 pub struct SsidResult {
@@ -88,31 +91,14 @@ impl Default for SsidResult {
     }
 }
 
-static mut RX_STATS_RAW: sl_wfx_indication_data_u = sl_wfx_indication_data_u {
-    raw_data: [0; 376],
-};
-
-pub fn wf200_get_rx_stats() -> sl_wfx_rx_stats_s {
-    let ret: sl_wfx_rx_stats_s;
-    unsafe { ret = RX_STATS_RAW.rx_stats; }
-    ret
-}
-
-pub fn wf200_get_rx_stats_raw() -> [u8; 376] {
-    let ret: [u8; 376];
-    unsafe { ret = RX_STATS_RAW.raw_data; }
-    ret
-}
-
 /// Note -- PDS spec says max PDS size is 256 bytes, so let's just pin the buffer at that
 /// returns true if send was OK
 pub fn wf200_send_pds(data: [u8; 256], length: u16) -> bool {
     if length >= 256 {
-        return false
+        return false;
     }
-
     let pds_data: *const c_types::c_char = (&data).as_ptr() as *const c_types::c_char;
-    if unsafe{ sl_wfx_send_configuration(pds_data, length as u_int32_t) } == SL_STATUS_OK {
+    if unsafe { sl_wfx_send_configuration(pds_data, length as u_int32_t) } == SL_STATUS_OK {
         true
     } else {
         false
@@ -122,23 +108,47 @@ pub fn wf200_send_pds(data: [u8; 256], length: u16) -> bool {
 // can't use initializer because calls in statics aren't allowed. :-/ that was a waste of time
 pub const SSID_ARRAY_SIZE: usize = 6;
 static mut SSID_ARRAY: [SsidResult; SSID_ARRAY_SIZE] = [
-    SsidResult{mac: [0;6], ssid: [0; 32], rssi: 0, channel: 0},
-    SsidResult{mac: [0;6], ssid: [0; 32], rssi: 0, channel: 0},
-    SsidResult{mac: [0;6], ssid: [0; 32], rssi: 0, channel: 0},
-    SsidResult{mac: [0;6], ssid: [0; 32], rssi: 0, channel: 0},
-    SsidResult{mac: [0;6], ssid: [0; 32], rssi: 0, channel: 0},
-    SsidResult{mac: [0;6], ssid: [0; 32], rssi: 0, channel: 0},
-    ];
+    SsidResult {
+        mac: [0; 6],
+        ssid: [0; 32],
+        rssi: 0,
+        channel: 0,
+    },
+    SsidResult {
+        mac: [0; 6],
+        ssid: [0; 32],
+        rssi: 0,
+        channel: 0,
+    },
+    SsidResult {
+        mac: [0; 6],
+        ssid: [0; 32],
+        rssi: 0,
+        channel: 0,
+    },
+    SsidResult {
+        mac: [0; 6],
+        ssid: [0; 32],
+        rssi: 0,
+        channel: 0,
+    },
+    SsidResult {
+        mac: [0; 6],
+        ssid: [0; 32],
+        rssi: 0,
+        channel: 0,
+    },
+    SsidResult {
+        mac: [0; 6],
+        ssid: [0; 32],
+        rssi: 0,
+        channel: 0,
+    },
+];
 static mut SSID_INDEX: usize = 0;
-static mut SSID_UPDATED: bool = false;
-
-pub fn wf200_ssid_updated() -> bool {
-    unsafe{ SSID_UPDATED }
-}
 
 pub fn wf200_ssid_get_list(ssid_list: &mut [[u8; 32]; SSID_ARRAY_SIZE]) {
-    unsafe{
-        SSID_UPDATED = false;
+    unsafe {
         for i in 0..SSID_ARRAY_SIZE {
             for j in 0..32 {
                 ssid_list[i][j] = SSID_ARRAY[i].ssid[j];
@@ -156,35 +166,18 @@ pub struct host_context {
     pub waited_event_id: u8,
     pub posted_event_id: u8,
 }
-static mut HOST_CONTEXT: host_context = host_context{ sl_wfx_firmware_download_progress: 0, waited_event_id: 0, posted_event_id: 0 };
-
-pub const MAX_SCAN_RESULTS: usize = 50;
-
-#[repr(C, packed)]
-#[derive(Copy, Clone)]
-pub struct scan_result_list_t {
-    pub ssid_def: sl_wfx_ssid_def_t,
-    pub mac: [u8; 6usize],
-    pub channel: u16,
-//    pub security_mode: sl_wfx_security_mode_bitmask_t,
-    pub rcpi: u16,
-}
-
-pub struct scan_data {
-    pub scan_list: [scan_result_list_t; MAX_SCAN_RESULTS],
-    pub scan_count: u8,
-    pub scan_count_web: u8,
-    pub scan_ongoing: bool,
-}
+static mut HOST_CONTEXT: host_context = host_context {
+    sl_wfx_firmware_download_progress: 0,
+    waited_event_id: 0,
+    posted_event_id: 0,
+};
 
 trait Empty<T> {
     fn empty() -> T;
 }
 impl Empty<sl_wfx_mac_address_t> for sl_wfx_mac_address_t {
     fn empty() -> sl_wfx_mac_address_t {
-        sl_wfx_mac_address_t {
-            octet: [0; 6usize],
-        }
+        sl_wfx_mac_address_t { octet: [0; 6usize] }
     }
 }
 impl Empty<sl_wfx_context_t> for sl_wfx_context_t {
@@ -212,47 +205,23 @@ static mut WIFI_CONTEXT: sl_wfx_context_t = sl_wfx_context_t {
     data_frame_id: 0,
     used_buffers: 0,
     wfx_opn: [0; 14usize],
-    mac_addr_0: sl_wfx_mac_address_t{ octet: [0; 6usize]},
-    mac_addr_1: sl_wfx_mac_address_t{ octet: [0; 6usize]},
+    mac_addr_0: sl_wfx_mac_address_t { octet: [0; 6usize] },
+    mac_addr_1: sl_wfx_mac_address_t { octet: [0; 6usize] },
     state: 0,
 };
 
-pub fn wf200_fw_build() -> u8 { unsafe{WIFI_CONTEXT.firmware_build} }
-pub fn wf200_fw_minor() -> u8 { unsafe{WIFI_CONTEXT.firmware_minor} }
-pub fn wf200_fw_major() -> u8 { unsafe{WIFI_CONTEXT.firmware_major} }
+pub fn wf200_fw_build() -> u8 {
+    unsafe { WIFI_CONTEXT.firmware_build }
+}
+pub fn wf200_fw_minor() -> u8 {
+    unsafe { WIFI_CONTEXT.firmware_minor }
+}
+pub fn wf200_fw_major() -> u8 {
+    unsafe { WIFI_CONTEXT.firmware_major }
+}
 
 pub fn wfx_init() -> sl_status_t {
-    unsafe{ sl_wfx_init(&mut WIFI_CONTEXT) }  // use this to drive porting of the wfx library
-}
-
-#[export_name = "sl_wfx_host_log"]
-pub unsafe extern "C" fn sl_wfx_host_log(dbgstr: *const c_types::c_char) {
-    let mut length: usize = 0;
-    while(dbgstr).add(length).read() != 0 {
-        length += 1;
-    }
-    let s = str::from_utf8(slice::from_raw_parts(dbgstr as *const u8, length)).expect("unable to parse");
-    sprintln!("{}", s);
-}
-
-#[export_name = "sl_wfx_host_log_1"]
-pub unsafe extern "C" fn sl_wfx_host_log_1(dbgstr: *const c_types::c_char, a: u32) {
-    let mut length: usize = 0;
-    while(dbgstr).add(length).read() != 0 {
-        length += 1;
-    }
-    let s = str::from_utf8(slice::from_raw_parts(dbgstr as *const u8, length)).expect("unable to parse");
-    sprintln!("{}: {}", s, a);
-}
-
-#[export_name = "sl_wfx_host_log_2"]
-pub unsafe extern "C" fn sl_wfx_host_log_2(dbgstr: *const c_types::c_char, a: u32, b: u32) {
-    let mut length: usize = 0;
-    while(dbgstr).add(length).read() != 0 {
-        length += 1;
-    }
-    let s = str::from_utf8(slice::from_raw_parts(dbgstr as *const u8, length)).expect("unable to parse");
-    sprintln!("{} {}/{}", s, a, b);
+    unsafe { sl_wfx_init(&mut WIFI_CONTEXT) } // use this to drive porting of the wfx library
 }
 
 #[export_name = "sl_wfx_host_spi_cs_assert"]
@@ -270,9 +239,8 @@ pub unsafe extern "C" fn sl_wfx_host_spi_cs_deassert() -> sl_status_t {
 }
 
 #[export_name = "sl_wfx_host_deinit_bus"]
-pub unsafe extern "C" fn sl_wfx_host_deinit_bus()-> sl_status_t {
+pub unsafe extern "C" fn sl_wfx_host_deinit_bus() -> sl_status_t {
     let mut wifi_csr = CSR::new(HW_WIFI_BASE as *mut u32);
-    if DEBUGGING2 { sprintln!("deinit_bus"); }
     wifi_csr.wo(utra::wifi::CONTROL, 0);
     wifi_csr.wo(utra::wifi::WIFI, 0);
     SL_STATUS_OK
@@ -291,22 +259,21 @@ pub unsafe extern "C" fn sl_wfx_host_disable_platform_interrupt() -> sl_status_t
 }
 
 #[export_name = "sl_wfx_host_init_bus"]
-pub unsafe extern "C" fn sl_wfx_host_init_bus()-> sl_status_t {
+pub unsafe extern "C" fn sl_wfx_host_init_bus() -> sl_status_t {
     let mut wifi_csr = CSR::new(HW_WIFI_BASE as *mut u32);
     wifi_csr.wo(utra::wifi::CONTROL, 0);
     wifi_csr.wo(utra::wifi::WIFI, 0);
-    if DEBUGGING2 { sprintln!("init_bus"); }
     SL_STATUS_OK
 }
 
 #[export_name = "sl_wfx_host_reset_chip"]
 pub unsafe extern "C" fn sl_wfx_host_reset_chip() -> sl_status_t {
     let mut wifi_csr = CSR::new(HW_WIFI_BASE as *mut u32);
-    if DEBUGGING2 { sprintln!("reset_chip"); }
     wifi_csr.wfo(utra::wifi::WIFI_RESET, 1);
     delay_ms(10);
     wifi_csr.wfo(utra::wifi::WIFI_RESET, 0);
     delay_ms(10);
+    SSID_SCAN_IN_PROGRESS = false;
     SL_STATUS_OK
 }
 
@@ -316,6 +283,7 @@ pub unsafe extern "C" fn sl_wfx_host_hold_in_reset() -> sl_status_t {
     wifi_csr.wfo(utra::wifi::WIFI_RESET, 1);
     // Allow a little time for reset signal to take effect before returning
     delay_ms(1);
+    SSID_SCAN_IN_PROGRESS = false;
     SL_STATUS_OK
 }
 
@@ -327,7 +295,6 @@ pub unsafe extern "C" fn sl_wfx_host_wait(wait_ms: u32) -> sl_status_t {
 
 #[export_name = "sl_wfx_host_set_wake_up_pin"]
 pub unsafe extern "C" fn sl_wfx_host_set_wake_up_pin(state: u8) -> sl_status_t {
-    sprintln!("WUP={}",state);
     let mut wifi_csr = CSR::new(HW_WIFI_BASE as *mut u32);
     if state == 0 {
         wifi_csr.rmwf(utra::wifi::WIFI_WAKEUP, 0);
@@ -372,13 +339,11 @@ pub unsafe extern "C" fn sl_wfx_host_spi_transfer_no_cs_assert(
     {
         let mut header_len_mtu = header_length / 2; // we do "MTU" in case header_len is odd. should never be but...this is their API
         let mut header_pos: usize = 0;
-        if DEBUG_SPI { sprintln!("headerlen: {}", header_length); }
         let headeru16: *mut u16 = header as *mut u16;
         while header_len_mtu > 0 {
             //let word: u16 = ((header.add(header_pos).read() as u16) << 8) | (header.add(header_pos + 1).read() as u16);
             let word: u16 = headeru16.add(header_pos).read();
             wifi_csr.wo(utra::wifi::TX, word as u32);
-            if DEBUG_SPI { sprintln!("header: {:02x} {:02x}", word >> 8, word & 0xff); }
             header_len_mtu -= 1;
             header_pos += 1;
 
@@ -387,7 +352,6 @@ pub unsafe extern "C" fn sl_wfx_host_spi_transfer_no_cs_assert(
             wifi_csr.wfo(utra::wifi::CONTROL_GO, 0);
         }
         if type_ == sl_wfx_host_bus_transfer_type_t_SL_WFX_BUS_READ {
-            if DEBUG_SPI { sprintln!("rxlen: {}", buffer_length); }
             let mut buffer_len_mtu = buffer_length / 2;
             let mut buffer_pos: usize = 0;
             let bufferu16: *mut u16 = buffer as *mut u16;
@@ -399,7 +363,6 @@ pub unsafe extern "C" fn sl_wfx_host_spi_transfer_no_cs_assert(
                 wifi_csr.wfo(utra::wifi::CONTROL_GO, 0);
 
                 let word: u16 = wifi_csr.rf(utra::wifi::RX_RX) as u16;
-                if DEBUG_SPI { sprintln!("rx: {:02x} {:02x}", word >> 8, word & 0xff); }
                 bufferu16.add(buffer_pos).write(word);
                 //buffer.add(buffer_pos).write((word >> 8) as u8);
                 //buffer.add(buffer_pos+1).write((word & 0xff) as u8);
@@ -407,7 +370,6 @@ pub unsafe extern "C" fn sl_wfx_host_spi_transfer_no_cs_assert(
                 buffer_pos += 1;
             }
         } else {
-            if DEBUG_SPI { sprintln!("txlen: {}", buffer_length); }
             // transmit the buffer
             let buffer_len_mtu: usize = buffer_length as usize / 2;
             let mut buffer_pos: usize = 0;
@@ -416,8 +378,7 @@ pub unsafe extern "C" fn sl_wfx_host_spi_transfer_no_cs_assert(
                 //let word: u16 = ((buffer.add(buffer_pos).read() as u16) << 8) | (buffer.add(buffer_pos+1).read() as u16);
                 let word: u16 = bufferu16.add(buffer_pos).read();
                 wifi_csr.wo(utra::wifi::TX, word as u32);
-                if DEBUG_SPI { sprintln!("tx: {:02x} {:02x}", word >> 8, word & 0xff); }
-//                buffer_len_mtu -= 1;
+                //                buffer_len_mtu -= 1;
                 buffer_pos += 1;
 
                 wifi_csr.wfo(utra::wifi::CONTROL_GO, 1);
@@ -425,7 +386,6 @@ pub unsafe extern "C" fn sl_wfx_host_spi_transfer_no_cs_assert(
                 wifi_csr.wfo(utra::wifi::CONTROL_GO, 0);
             }
         }
-
     }
     SL_STATUS_OK
 }
@@ -439,47 +399,24 @@ pub unsafe extern "C" fn sl_wfx_host_spi_transfer_no_cs_assert(
 #[doc = ""]
 #[doc = " @note Called by the driver every time it needs memory"]
 #[export_name = "sl_wfx_host_allocate_buffer"]
-/*
-pub unsafe extern "C" fn sl_wfx_host_allocate_buffer(
-    buffer: *mut *mut c_types::c_void,
-    type_: sl_wfx_buffer_type_t,
-    buffer_size: u32,
-) -> sl_status_t {
-    if (WFX_RAM_ALLOC + buffer_size as usize) < (WFX_RAM_LENGTH + WFX_RAM_OFFSET) as usize &&
-        WFX_PTR_COUNT < WFX_MAX_PTRS as u8 {
-        *buffer = WFX_RAM_ALLOC as *mut c_types::c_void;
-        unsafe{ WFX_PTR_LIST[WFX_PTR_COUNT as usize] = WFX_RAM_ALLOC; }
-
-        unsafe{ WFX_PTR_COUNT += 1; }
-        unsafe{ WFX_RAM_ALLOC += buffer_size as usize };
-
-        SL_STATUS_OK
-    } else {
-        SL_STATUS_ALLOCATION_FAILED
-    }
-}
-*/
 pub unsafe extern "C" fn sl_wfx_host_allocate_buffer(
     buffer: *mut *mut c_types::c_void,
     _type_: sl_wfx_buffer_type_t,
-    buffer_size: u32,
+    _buffer_size: u32,
 ) -> sl_status_t {
+    // DANGER! DANGER! This code appears to work, but it does not check the buffer size argument!
+    // TODO: Check the requested buffer size argument
+
     // find the first "0" entry in the pointer list
     let mut i = 0;
     while (WFX_PTR_LIST[i] != 0) && (i < WFX_MAX_PTRS as usize) {
         i += 1;
     }
     if i == WFX_MAX_PTRS {
-        if DEBUG_MALLOC {
-            sprintln!("malloc failed");
-        }
-        return SL_STATUS_ALLOCATION_FAILED
+        return SL_STATUS_ALLOCATION_FAILED;
     }
     WFX_PTR_LIST[i] = WFX_RAM_ALLOC + i * (WFX_RAM_LENGTH / WFX_MAX_PTRS);
     *buffer = WFX_PTR_LIST[i] as *mut c_types::c_void;
-    if DEBUG_MALLOC {
-        sprintln!("allocated index {}|{:08x} reqlen {} bytes", i, *buffer as u32, buffer_size);
-    }
     SL_STATUS_OK
 }
 
@@ -489,73 +426,18 @@ pub unsafe extern "C" fn sl_wfx_host_allocate_buffer(
 #[doc = " @param type is the type of buffer to free (see ::sl_wfx_buffer_type_t)"]
 #[doc = " @returns Returns SL_STATUS_OK if successful, SL_STATUS_FAIL otherwise"]
 #[export_name = "sl_wfx_host_free_buffer"]
-/*
-pub unsafe extern "C" fn sl_wfx_host_free_buffer(
-    buffer: *mut c_types::c_void,
-    type_: sl_wfx_buffer_type_t,
-) -> sl_status_t {
-    // copy the list of pointers to a temp struct, omitting the one we are looking to free
-    // reset the ALLOC pointer to the last element.
-    let mut temp_ptr_list: [usize; WFX_MAX_PTRS] = [0; WFX_MAX_PTRS];
-    let mut temp_ptr = 0;
-    let mut found = false;
-    for ptr in 0..WFX_MAX_PTRS {
-        if WFX_PTR_LIST[ptr] == buffer as usize {
-            found = true;
-            if buffer as usize != 0 {
-                unsafe{ WFX_PTR_COUNT -= 1; } // decrement the list
-            }
-            continue; // skip copying
-        } else {
-            temp_ptr_list[temp_ptr] = WFX_PTR_LIST[ptr];
-            temp_ptr += 1;
-        }
-    }
-
-    // fail if we didn't find anything, or if somehow ptr_count wrapped around
-    if found == false || WFX_PTR_COUNT > WFX_MAX_PTRS as u8 {
-        SL_STATUS_FAIL
-    } else {
-        // copy the temp list to the master list
-        let mut top_mem: usize = 0;
-        for ptr in 0..WFX_MAX_PTRS {
-            unsafe{ WFX_PTR_LIST[ptr] = temp_ptr_list[ptr]; }
-            if temp_ptr_list[ptr] > top_mem {
-                top_mem = temp_ptr_list[ptr];
-            }
-        }
-        // if no entries in list, top_mem is 0 and should be reset to base of RAM
-        if top_mem == 0 {
-            top_mem = WFX_RAM_OFFSET;
-        }
-        // sanity check top_mem
-        if top_mem < WFX_RAM_OFFSET || top_mem > (WFX_RAM_OFFSET + WFX_RAM_LENGTH) {
-            SL_STATUS_FAIL
-        } else {
-            unsafe{ WFX_RAM_ALLOC = top_mem };
-            SL_STATUS_OK
-        }
-    }
-}*/
 pub unsafe extern "C" fn sl_wfx_host_free_buffer(
     buffer: *mut c_types::c_void,
     _type_: sl_wfx_buffer_type_t,
 ) -> sl_status_t {
     let mut i = 0;
     let addr: usize = (buffer as *mut c_types::c_uint) as usize;
-    if DEBUG_MALLOC {
-        sprintln!("request to free {:08x}", addr);
-    }
     while (WFX_PTR_LIST[i] != addr) && (i < WFX_MAX_PTRS as usize) {
         i = i + 1;
     }
     if i == WFX_MAX_PTRS {
-        if DEBUG_MALLOC {
-            sprintln!("free failed");
-        }
         return SL_STATUS_ALLOCATION_FAILED;
     }
-    if DEBUG_MALLOC { sprintln!("freeing index {}|{:08x}", i, WFX_PTR_LIST[i]); }
     WFX_PTR_LIST[i] = 0;
     SL_STATUS_OK
 }
@@ -568,7 +450,7 @@ pub unsafe extern "C" fn sl_wfx_host_init() -> sl_status_t {
     WFX_PTR_COUNT = 0;
     WFX_PTR_LIST = [0; WFX_MAX_PTRS];
     HOST_CONTEXT.sl_wfx_firmware_download_progress = 0;
-//    HOST_CONTEXT.waited_event_id = 0;  // this is apparently side-effected elsewhere
+    //    HOST_CONTEXT.waited_event_id = 0;  // this is apparently side-effected elsewhere
     HOST_CONTEXT.posted_event_id = 0;
     WIFI_CONTEXT = sl_wfx_context_t {
         event_payload_buffer: [0; 512usize],
@@ -578,12 +460,13 @@ pub unsafe extern "C" fn sl_wfx_host_init() -> sl_status_t {
         data_frame_id: 0,
         used_buffers: 0,
         wfx_opn: [0; 14usize],
-        mac_addr_0: sl_wfx_mac_address_t{ octet: [0; 6usize]},
-        mac_addr_1: sl_wfx_mac_address_t{ octet: [0; 6usize]},
+        mac_addr_0: sl_wfx_mac_address_t { octet: [0; 6usize] },
+        mac_addr_1: sl_wfx_mac_address_t { octet: [0; 6usize] },
         state: 0,
     };
     SL_STATUS_OK
 }
+
 #[export_name = "sl_wfx_host_deinit"]
 pub unsafe extern "C" fn sl_wfx_host_deinit() -> sl_status_t {
     WFX_RAM_ALLOC = WFX_RAM_OFFSET;
@@ -618,12 +501,14 @@ pub unsafe extern "C" fn sl_wfx_host_wait_for_confirmation(
         }
         if confirmation_id == HOST_CONTEXT.posted_event_id {
             HOST_CONTEXT.posted_event_id = 0;
-            if event_payload_out != (::core::ptr::null::<c_types::c_void> as *mut *mut c_types::c_void) {
-                *event_payload_out = WIFI_CONTEXT.event_payload_buffer.as_ptr() as *mut c_types::c_void;
+            if event_payload_out
+                != (::core::ptr::null::<c_types::c_void> as *mut *mut c_types::c_void)
+            {
+                *event_payload_out =
+                    WIFI_CONTEXT.event_payload_buffer.as_ptr() as *mut c_types::c_void;
             }
             return SL_STATUS_OK;
         } else {
-            if DEBUGGING{ sprintln!("confid: {}", HOST_CONTEXT.posted_event_id); }
             delay_ms(1);
         }
     }
@@ -648,27 +533,12 @@ pub unsafe extern "C" fn sl_wfx_host_setup_waited_event(event_id: u8) -> sl_stat
 #[doc = " @param frame_len is size of the frame"]
 #[doc = " @returns Returns SL_STATUS_OK if successful, SL_STATUS_FAIL otherwise"]
 #[export_name = "sl_wfx_host_transmit_frame"]
-pub unsafe extern "C" fn sl_wfx_host_transmit_frame(frame: *mut c_types::c_void, frame_len: u32) -> sl_status_t {
+pub unsafe extern "C" fn sl_wfx_host_transmit_frame(
+    frame: *mut c_types::c_void,
+    frame_len: u32,
+) -> sl_status_t {
     let ret: sl_status_t;
-    if DEBUGGING {
-        let u8frame: *const u8 = frame as *const u8;
-        sprint!("TX> 0x{:x}: ", frame as u32);
-        for i in 0 .. frame_len {
-            if i < 4 {
-                sprint!("{:02x}", u8frame.add(i as usize).read());
-            } else if i >= 4 && i < 6 {
-                sprint!(" {:02x} ", u8frame.add(i as usize).read());
-            } else {
-                if u8frame.add(i as usize).read() != 0 {
-                    sprint!("{}", u8frame.add(i as usize).read() as char);
-                } else {
-                    sprint!("NULL");
-                }
-            }
-        }
-        sprintln!("");
-    }
-    ret = sl_wfx_data_write( frame, frame_len );
+    ret = sl_wfx_data_write(frame, frame_len);
     ret
 }
 
@@ -692,8 +562,12 @@ pub unsafe extern "C" fn sl_wfx_host_get_firmware_size(firmware_size: *mut u32) 
 #[doc = ""]
 #[doc = " @note Called multiple times during the driver initialization phase"]
 #[export_name = "sl_wfx_host_get_firmware_data"]
-pub unsafe extern "C" fn sl_wfx_host_get_firmware_data(data: *mut *const u8, data_size: u32) -> sl_status_t {
-    *data = (WFX_FIRMWARE_OFFSET + HOST_CONTEXT.sl_wfx_firmware_download_progress as usize) as *const u8;
+pub unsafe extern "C" fn sl_wfx_host_get_firmware_data(
+    data: *mut *const u8,
+    data_size: u32,
+) -> sl_status_t {
+    *data = (WFX_FIRMWARE_OFFSET + HOST_CONTEXT.sl_wfx_firmware_download_progress as usize)
+        as *const u8;
     HOST_CONTEXT.sl_wfx_firmware_download_progress += data_size;
     SL_STATUS_OK
 }
@@ -740,34 +614,6 @@ pub unsafe extern "C" fn strlen(__s: *const c_types::c_char) -> c_types::c_ulong
     len as c_types::c_ulong
 }
 
-#[export_name = "bt_ffi_dbg"]
-pub unsafe extern "C" fn bt_ffi_dbg(dbgstr: *const c_types::c_char) {
-    let mut length: usize = 0;
-    while(dbgstr).add(length).read() != 0 {
-        length += 1;
-    }
-    let s = str::from_utf8(slice::from_raw_parts(dbgstr as *const u8, length)).expect("unable to parse");
-    sprintln!("***dbg: {}", s);
-}
-#[export_name = "bt_ffi_dbg_u16"]
-pub unsafe extern "C" fn bt_ffi_dbg_u16(dbgstr: *const c_types::c_char, val: u16) {
-    let mut length: usize = 0;
-    while(dbgstr).add(length).read() != 0 {
-        length += 1;
-    }
-    let s = str::from_utf8(slice::from_raw_parts(dbgstr as *const u8, length)).expect("unable to parse");
-    sprintln!("***dbg: {}: 0x{:04x}", s, val);
-}
-#[export_name = "bt_ffi_dbg_u32"]
-pub unsafe extern "C" fn bt_ffi_dbg_u32(dbgstr: *const c_types::c_char, val: u32) {
-    let mut length: usize = 0;
-    while(dbgstr).add(length).read() != 0 {
-        length += 1;
-    }
-    let s = str::from_utf8(slice::from_raw_parts(dbgstr as *const u8, length)).expect("unable to parse");
-    sprintln!("***dbg: {}: 0x{:08x}", s, val);
-}
-
 /// this is a hyper-targeted implementation of strtoul for the instance where it is called in
 /// referenced by sl_wfx.c:1527 (wfx-fullMAC-driver/wfx_fmac_driver/sl_wfx.c:1527):
 /// endptr is NULL, base is 16
@@ -781,11 +627,13 @@ pub unsafe extern "C" fn strtoul(
     assert!(__base == 16 as c_types::c_int);
     assert!(__endptr == ::core::ptr::null::<c_types::c_void> as *mut *mut c_types::c_char);
     let mut length: usize = 0;
-    while(__nptr).add(length).read() != 0 {
+    while (__nptr).add(length).read() != 0 {
         length += 1;
     }
-    let s = str::from_utf8(slice::from_raw_parts(__nptr as *const u8, length)).expect("unable to parse string");
-    usize::from_str_radix(s.trim_start_matches("0x"), 16).expect("unable to parse num") as c_types::c_ulong
+    let s = str::from_utf8(slice::from_raw_parts(__nptr as *const u8, length))
+        .expect("unable to parse string");
+    usize::from_str_radix(s.trim_start_matches("0x"), 16).expect("unable to parse num")
+        as c_types::c_ulong
 }
 
 #[doc = " @brief Driver hook to retrieve a PDS line"]
@@ -802,10 +650,7 @@ pub unsafe extern "C" fn sl_wfx_host_get_pds_data(
 ) -> sl_status_t {
     // pds should be static data so it will not go out of scope when this function terminates
     // so weird! suspicious bunnie is suspicious.
-    //let pds = include_bytes!("bt-wf200-pds.in");
-    //*pds_data = (&pds).as_ptr().add(0) as *const c_types::c_char;
     *pds_data = (&PDS_DATA[index as usize]).as_ptr() as *const c_types::c_char;
-
     SL_STATUS_OK
 }
 
@@ -818,37 +663,34 @@ pub unsafe extern "C" fn sl_wfx_host_get_pds_data(
 #[export_name = "sl_wfx_host_get_pds_size"]
 pub unsafe extern "C" fn sl_wfx_host_get_pds_size(pds_size: *mut u16) -> sl_status_t {
     *pds_size = PDS_DATA.len() as u16;
-
     SL_STATUS_OK
 }
 
 fn sl_wfx_connect_callback(_mac: [u8; 6usize], status: u32) {
     match status {
         sl_wfx_fmac_status_e_WFM_STATUS_SUCCESS => {
-            sprintln!("Connected");
-            unsafe{ WIFI_CONTEXT.state |= sl_wfx_state_t_SL_WFX_STA_INTERFACE_CONNECTED; }
-            // TODO: callback to lwip_set_sta_link_up -- setup the IP link
-            if unsafe{WIFI_CONTEXT.state & sl_wfx_state_t_SL_WFX_AP_INTERFACE_UP} == 0 {
-                unsafe { // wrap FFI C calls in unsafe
-                    sl_wfx_set_power_mode(sl_wfx_pm_mode_e_WFM_PM_MODE_PS, 0);
-                    sl_wfx_enable_device_power_save();
-                }
+            sprintln!("WFM_STATUS_SUCCESS");
+            unsafe {
+                WIFI_CONTEXT.state |= sl_wfx_state_t_SL_WFX_STA_INTERFACE_CONNECTED;
+                // TODO: callback to lwip_set_sta_link_up -- setup the IP link
+                sl_wfx_set_power_mode(sl_wfx_pm_mode_e_WFM_PM_MODE_PS, 0);
+                sl_wfx_enable_device_power_save();
             }
         }
         sl_wfx_fmac_status_e_WFM_STATUS_NO_MATCHING_AP => {
-            sprintln!("Connection failed, access point not found.")
+            sprintln!("STATUS_NO_MATCHING_AP")
         }
         sl_wfx_fmac_status_e_WFM_STATUS_CONNECTION_ABORTED => {
-            sprintln!("Connectiona aborted.")
+            sprintln!("STATUS_CONNECTION_ABORTED")
         }
         sl_wfx_fmac_status_e_WFM_STATUS_CONNECTION_TIMEOUT => {
-            sprintln!("Connection timeout.")
+            sprintln!("STATUS_CONNECTION_TIMEOUT")
         }
         sl_wfx_fmac_status_e_WFM_STATUS_CONNECTION_REJECTED_BY_AP => {
-            sprintln!("Connection rejected by the access point.")
+            sprintln!("WFM_STATUS_CONNECTION_REJECTED")
         }
         sl_wfx_fmac_status_e_WFM_STATUS_CONNECTION_AUTH_FAILURE => {
-            sprintln!("Connection authenication failure.")
+            sprintln!("WFM_STATUS_CONNECTION_AUTH_FAILURE")
         }
         _ => {
             sprintln!("Connection attempt error.")
@@ -858,105 +700,88 @@ fn sl_wfx_connect_callback(_mac: [u8; 6usize], status: u32) {
 
 fn sl_wfx_disconnect_callback(_mac: [u8; 6usize], _reason: u16) {
     sprintln!("Disconnected");
-    unsafe{ WIFI_CONTEXT.state &= !sl_wfx_state_t_SL_WFX_STA_INTERFACE_CONNECTED; }
+    unsafe {
+        WIFI_CONTEXT.state &= !sl_wfx_state_t_SL_WFX_STA_INTERFACE_CONNECTED;
+    }
     // TODO: callback to lwip_set_sta_link_down -- teardown the IP link
-}
-
-fn sl_wfx_start_ap_callback(status: u32) {
-    if status == 0 {
-        sprintln!("AP started");
-        unsafe{ WIFI_CONTEXT.state |= sl_wfx_state_t_SL_WFX_AP_INTERFACE_UP; }
-        // TODO: callback to lwip_set_ap_link_up() -- if we are to be an AP!!!
-        unsafe { // wrap FFI C calls in unsafe
-            sl_wfx_set_power_mode(sl_wfx_pm_mode_e_WFM_PM_MODE_ACTIVE, 0);
-            sl_wfx_disable_device_power_save();
-        }
-    } else {
-        sprintln!("AP start failed");
-    }
-}
-
-fn sl_wfx_stop_ap_callback() {
-    // TODO: stop the DHCP server
-    sprintln!("SoftAP stopped.");
-    unsafe{ WIFI_CONTEXT.state &= !sl_wfx_state_t_SL_WFX_AP_INTERFACE_UP; }
-    // TODO: lwip_set_ap_link_down -- bring the AP link down
-
-    if unsafe{ WIFI_CONTEXT.state & sl_wfx_state_t_SL_WFX_STA_INTERFACE_CONNECTED } != 0 {
-        unsafe { // wrap FFI C calls in unsafe
-            sl_wfx_set_power_mode(sl_wfx_pm_mode_e_WFM_PM_MODE_PS, 0);
-            sl_wfx_enable_device_power_save();
-        }
-    }
 }
 
 fn sl_wfx_host_received_frame_callback(_rx_buffer: *const sl_wfx_received_ind_t) {
     // TODO: do something with received ethernet frames!
 }
 
-fn sl_wfx_scan_result_callback(scan_result: *const sl_wfx_scan_result_ind_body_t) {
-    unsafe { // because raw pointer dereferences
-        let sr = &*scan_result;
-        if sr.ssid_def.ssid_length == 0 || sr.ssid_def.ssid[0] == 0 {
-            sprintln!("scan-- ignoring hidden SSID");
-            return;
+unsafe fn sl_wfx_scan_result_callback(scan_result: *const sl_wfx_scan_result_ind_body_t) {
+    let sr = &*scan_result;
+    if sr.ssid_def.ssid_length == 0 || sr.ssid_def.ssid[0] == 0 {
+        // Silently ignore scan results for hidden SSIDs since they're of no use to us
+        return;
+    }
+    let ssid = match str::from_utf8(slice::from_raw_parts(&sr.ssid_def.ssid as *const u8, 32)) {
+        Ok(s) => s,
+        _ => "",
+    };
+    if true {
+        // Debug print the SSID result
+        let channel = core::ptr::addr_of!(sr.channel).read_unaligned();
+        let dbm = 32768 - ((sr.rcpi - 220) / 2);
+        sprint!("ssid {:2} -{} {:02X}", channel, dbm, sr.mac[0],);
+        for i in 1..=5 {
+            sprint!(":{:02X}", sr.mac[i]);
         }
-        let ssid = match str::from_utf8(slice::from_raw_parts(&sr.ssid_def.ssid as *const u8, 32)) {
-            Ok(s) => s,
-            _ => "",
-        };
-        sprintln!("scan-- ch:{} str:-{} mac:{:02x}{:02x}{:02x}{:02x}{:02x}{:02x} ssid:{}",
-            core::ptr::addr_of!(sr.channel).read_unaligned(),
-            32768 - ((sr.rcpi - 220) / 2),
+        sprintln!(" {}", ssid);
+    }
+    if SSID_INDEX >= SSID_ARRAY_SIZE {
+        SSID_INDEX = 0;
+    }
+    SSID_ARRAY[SSID_INDEX] = SsidResult {
+        mac: [
             sr.mac[0], sr.mac[1], sr.mac[2], sr.mac[3], sr.mac[4], sr.mac[5],
-            ssid
-        );
-        if SSID_INDEX >= SSID_ARRAY_SIZE {
-            SSID_INDEX = 0;
-        }
-        sprintln!("setting slot {} for {}", SSID_INDEX, ssid);
-        SSID_ARRAY[SSID_INDEX] = SsidResult {
-            mac: [sr.mac[0], sr.mac[1], sr.mac[2], sr.mac[3], sr.mac[4], sr.mac[5]],
-            rssi: sr.rcpi,
-            channel: sr.channel as u8,
-            ssid: [0; 32]
+        ],
+        rssi: sr.rcpi,
+        channel: sr.channel as u8,
+        ssid: [0; 32],
+    };
+    for i in 0..32 {
+        // Filter nulls to '.' to bypass `ssid scan` shellchat command's broken filter
+        SSID_ARRAY[SSID_INDEX].ssid[i] = match sr.ssid_def.ssid[i] {
+            0 => '.' as u8,
+            c => c,
         };
-        for i in 0..32 {
-            SSID_ARRAY[SSID_INDEX].ssid[i] = sr.ssid_def.ssid[i];
-            // TODO: undo this filter
-            // This changes nulls to spaces so as not to confuse xous shellchat ssid command
-            if SSID_ARRAY[SSID_INDEX].ssid[i] == 0 {
-                SSID_ARRAY[SSID_INDEX].ssid[i] = '.' as u8;
-            }
-        }
-        if SSID_ARRAY_SIZE == 6 {
-            SSID_INDEX = match SSID_INDEX {
-                0 => 1,
-                1 => 2,
-                2 => 3,
-                3 => 4,
-                4 => 5,
-                _ => 0,
-            };
-        } else {
-            SSID_INDEX = (SSID_INDEX + 1) % SSID_ARRAY_SIZE;
-        }
+    }
+    // This is like `n = (n+1) % m`, but % is slow on the EC's minimal RV32I core
+    SSID_INDEX += 1;
+    if SSID_INDEX >= SSID_ARRAY_SIZE {
+        SSID_INDEX = 0;
     }
 }
 
 pub fn wfx_start_scan() -> sl_status_t {
     let result: sl_status_t;
     unsafe {
-        SSID_UPDATED = true;
-        result = sl_wfx_send_scan_command(sl_wfx_scan_mode_e_WFM_SCAN_MODE_ACTIVE as u16,
-            0 as *const u8, 0, 0 as *const sl_wfx_ssid_def_t, 0, 0 as *const u8, 0, 0 as *const u8);
+        SSID_SCAN_IN_PROGRESS = true;
+        result = sl_wfx_send_scan_command(
+            sl_wfx_scan_mode_e_WFM_SCAN_MODE_ACTIVE as u16,
+            0 as *const u8,
+            0,
+            0 as *const sl_wfx_ssid_def_t,
+            0,
+            0 as *const u8,
+            0,
+            0 as *const u8,
+        );
     }
     result
 }
 
 fn sl_wfx_scan_complete_callback(_status: u32) {
     sprintln!("scan complete");
-    unsafe{ SSID_UPDATED = false; }
+    unsafe {
+        SSID_SCAN_IN_PROGRESS = false;
+    }
+}
+
+pub fn wfx_ssid_scan_in_progress() -> bool {
+    unsafe { SSID_SCAN_IN_PROGRESS }
 }
 
 pub fn wfx_handle_event() -> sl_status_t {
@@ -986,125 +811,96 @@ pub fn wfx_drain_event_queue(limit: usize) {
 #[doc = ""]
 #[doc = " @note Called by ::sl_wfx_receive_frame function"]
 #[export_name = "sl_wfx_host_post_event"]
-pub unsafe extern "C" fn sl_wfx_host_post_event(event_payload: *mut sl_wfx_generic_message_t) -> sl_status_t {
+pub unsafe extern "C" fn sl_wfx_host_post_event(
+    event_payload: *mut sl_wfx_generic_message_t,
+) -> sl_status_t {
     let msg_type: u32 = (*event_payload).header.id as u32;
-
-    if DEBUGGING {
-        sprintln!("msg_type: 0x{:x}", msg_type);
-    }
     match msg_type {
         sl_wfx_indications_ids_e_SL_WFX_CONNECT_IND_ID => {
-            let connect_indication: sl_wfx_connect_ind_t = *(event_payload as *const sl_wfx_connect_ind_t);
+            let connect_indication: sl_wfx_connect_ind_t =
+                *(event_payload as *const sl_wfx_connect_ind_t);
             sl_wfx_connect_callback(connect_indication.body.mac, connect_indication.body.status);
-        },
+        }
         sl_wfx_indications_ids_e_SL_WFX_DISCONNECT_IND_ID => {
-            let disconnect_indication: sl_wfx_disconnect_ind_t = *(event_payload as *const sl_wfx_disconnect_ind_t);
-            sl_wfx_disconnect_callback(disconnect_indication.body.mac, disconnect_indication.body.reason);
-        },
-        sl_wfx_indications_ids_e_SL_WFX_START_AP_IND_ID => {
-            let start_ap_indication: sl_wfx_start_ap_ind_t = *(event_payload as *const sl_wfx_start_ap_ind_t);
-            sl_wfx_start_ap_callback(start_ap_indication.body.status);
-        },
-        sl_wfx_indications_ids_e_SL_WFX_STOP_AP_IND_ID => {
-            sl_wfx_stop_ap_callback();
-        },
+            let disconnect_indication: sl_wfx_disconnect_ind_t =
+                *(event_payload as *const sl_wfx_disconnect_ind_t);
+            sl_wfx_disconnect_callback(
+                disconnect_indication.body.mac,
+                disconnect_indication.body.reason,
+            );
+        }
         sl_wfx_indications_ids_e_SL_WFX_RECEIVED_IND_ID => {
-            let ethernet_frame: *const sl_wfx_received_ind_t = event_payload as *const sl_wfx_received_ind_t;
+            let ethernet_frame: *const sl_wfx_received_ind_t =
+                event_payload as *const sl_wfx_received_ind_t;
             if (*ethernet_frame).body.frame_type == 0 {
-                sl_wfx_host_received_frame_callback( ethernet_frame );
+                sl_wfx_host_received_frame_callback(ethernet_frame);
             }
-        },
+        }
         sl_wfx_indications_ids_e_SL_WFX_SCAN_RESULT_IND_ID => {
-            let scan_result: *const sl_wfx_scan_result_ind_t = event_payload as *const sl_wfx_scan_result_ind_t;
+            let scan_result: *const sl_wfx_scan_result_ind_t =
+                event_payload as *const sl_wfx_scan_result_ind_t;
             sl_wfx_scan_result_callback(&(*scan_result).body);
-        },
+        }
         sl_wfx_indications_ids_e_SL_WFX_SCAN_COMPLETE_IND_ID => {
-            let scan_complete: *const sl_wfx_scan_complete_ind_t = event_payload as *const sl_wfx_scan_complete_ind_t;
+            let scan_complete: *const sl_wfx_scan_complete_ind_t =
+                event_payload as *const sl_wfx_scan_complete_ind_t;
             sl_wfx_scan_complete_callback((*scan_complete).body.status);
-        },
-        sl_wfx_indications_ids_e_SL_WFX_AP_CLIENT_CONNECTED_IND_ID => {
-            unimplemented!();
-        },
-        sl_wfx_indications_ids_e_SL_WFX_AP_CLIENT_REJECTED_IND_ID => {
-            unimplemented!();
-        },
-        sl_wfx_indications_ids_e_SL_WFX_AP_CLIENT_DISCONNECTED_IND_ID => {
-            unimplemented!();
-        },
+        }
         sl_wfx_general_indications_ids_e_SL_WFX_GENERIC_IND_ID => {
-            let generic_indication: *const sl_wfx_generic_ind_t = event_payload as *const sl_wfx_generic_ind_t;
-            if (*generic_indication).body.indication_type == sl_wfx_generic_indication_type_e_SL_WFX_GENERIC_INDICATION_TYPE_RX_STATS {
-                RX_STATS_RAW = (*generic_indication).body.indication_data;
-            } else {
-                if DEBUGGING {
-                    sprintln!(
-                        "SL_WFX_GENERIC_IND_ID type {}, attempting to dispach",
-                        core::ptr::addr_of!((*generic_indication).body.indication_type).read_unaligned()
-                    );
-                }
-                if (*generic_indication).body.indication_type == sl_wfx_generic_indication_type_e_SL_WFX_GENERIC_INDICATION_TYPE_STRING {
-                    let dbgstr = (*generic_indication).body.indication_data.raw_data;
-                    if DEBUGGING {
-                        let mut length = 0;
-                        while dbgstr[length] != 0 {
-                            length += 1;
-                        }
-                        let s = str::from_utf8_unchecked(&dbgstr[0..length]);
-                        sprintln!("String repr: {}", s);
-                    }
-                } else {
-                    if DEBUGGING {sprintln!("type not handled, ignoring");}
-                }
-            }
-        },
+            let generic_ind: *const sl_wfx_generic_ind_t =
+                event_payload as *const sl_wfx_generic_ind_t;
+            let ind_type = (*generic_ind).body.indication_type;
+            sprintln!("WFX_GENERIC_IND {:X}", ind_type);
+        }
         sl_wfx_general_indications_ids_e_SL_WFX_EXCEPTION_IND_ID => {
-            sprintln!("Firmware exception");
-            let firmware_exception: *const sl_wfx_exception_ind_t = event_payload as *const sl_wfx_exception_ind_t;
-            sprintln!("Exeption data = ");
+            let exception_ind: *const sl_wfx_exception_ind_t =
+                event_payload as *const sl_wfx_exception_ind_t;
+            sprintln!("WFX_EXCEPTION_IND:");
             for i in 0..SL_WFX_EXCEPTION_DATA_SIZE {
-                sprint!("{:02x} ", (*firmware_exception).body.data[i as usize]);
+                sprint!("{:02X} ", (*exception_ind).body.data[i as usize]);
             }
-            sprintln!("End dump.");
-        },
+        }
         sl_wfx_general_indications_ids_e_SL_WFX_ERROR_IND_ID => {
-            sprintln!("Firmware error");
-            let firmware_error: *const sl_wfx_error_ind_t = event_payload as *const sl_wfx_error_ind_t;
+            let firmware_error: *const sl_wfx_error_ind_t =
+                event_payload as *const sl_wfx_error_ind_t;
             let error = core::ptr::addr_of!((*firmware_error).body.type_).read_unaligned();
             // SL_WFX_HIF_BUS_ERROR means something got messed up on the SPI bus between the UP5K and the
             // WF200. The one instance I've seen of that happened because of using some weird pointer casting stuff on a
             // the control register argument to wf_receive_frame(). Using `let cr: u16 = 0; wfx_receive_frame(&mut cr);`
             // fixed the problem.
+            sprint!("WFX_ERROR_IND: ");
             match error {
-                SL_WFX_HIF_BUS_ERROR => sprintln!("SL_WFX_HIF_BUS_ERROR"),
-                _ => sprintln!("sl_wfx_error_t = {}", error),
+                SL_WFX_HIF_BUS_ERROR => sprintln!("WFX_HIF_BUS_ERROR"),
+                _ => sprintln!("{:X}", error),
             }
-        },
+        }
         sl_wfx_general_indications_ids_e_SL_WFX_STARTUP_IND_ID => {
-            sprintln!("wf200 started!");
-        },
+            sprintln!("WFX_STARTUP");
+        }
         sl_wfx_general_confirmations_ids_e_SL_WFX_CONFIGURATION_CNF_ID => {
             // this occurs during configuration, and is handled specially
-        },
+        }
         sl_wfx_confirmations_ids_e_SL_WFX_START_SCAN_CNF_ID => {
-            sprintln!("scan start confirmation.");
-        },
+            sprintln!("WFX_START_SCAN");
+        }
         sl_wfx_confirmations_ids_e_SL_WFX_STOP_SCAN_CNF_ID => {
-            sprintln!("scan stop confirmation.");
-        },
+            sprintln!("WFX_STOP_SCAN");
+        }
         0 => {
             // Whatever... I guess this is fine?
             // Seems like this branch gets hit with a `0` value if there are no events pending
             // That happens a lot if the control loop polls, so ignore this
         }
         _ => {
-            sprintln!("Unhandled return code from wfx200: {}", msg_type);
-        },
+            sprintln!("WFX Unhandled Event: {:X}", msg_type);
+        }
     }
 
     if HOST_CONTEXT.waited_event_id == (*event_payload).header.id {
         if (*event_payload).header.length < 512usize as u16 {
             for i in 0..(*event_payload).header.length {
-                WIFI_CONTEXT.event_payload_buffer[i as usize] = (event_payload as *const u8).add(i as usize).read();
+                WIFI_CONTEXT.event_payload_buffer[i as usize] =
+                    (event_payload as *const u8).add(i as usize).read();
             }
             HOST_CONTEXT.posted_event_id = (*event_payload).header.id;
         }

--- a/sw/wfx_rs/src/hal_wf200/debug.rs
+++ b/sw/wfx_rs/src/hal_wf200/debug.rs
@@ -1,23 +1,101 @@
-#[allow(dead_code)]
+//! Serial debug for wishbone-bridge crossover UART.
+//!
+//! To enable serial debug printing:
+//!  1. Build and flash EC gateware with `debugonly = True`
+//!  2. In ../Cargo.toml, enable the "debug_uart" feature for this crate
+//!
+
+// TODO: switch from println!(...) to logln!(...) and get rid of this allow
+#![allow(unused_macros, dead_code)]
+
+#[cfg(feature = "debug_uart")]
 use utralib::generated::*;
 
-pub struct Uart {
+#[cfg(feature = "debug_uart")]
+use crate::betrusted_hal::hal_time::delay_ms;
+
+/// The flow control timeout determines how long putc() waits to decide if the
+/// wishbone-bridge connection is down before dropping characters.
+#[cfg(feature = "debug_uart")]
+const FLOW_CONTROL_TIMEOUT_MS: usize = 1000;
+
+#[derive(PartialOrd, PartialEq)]
+#[allow(dead_code)]
+pub enum LL {
+    Trace = 0,
+    Debug = 1,
+    Info = 2,
+    Warn = 3,
+    Error = 4,
+    Fatal = 5,
 }
+
+static mut LOG_LEVEL: LL = LL::Info;
+
+pub fn set_log_level(level: LL) {
+    unsafe {
+        LOG_LEVEL = level;
+    }
+}
+
+pub struct Uart {}
 
 #[cfg(feature = "debug_uart")]
 impl Uart {
+    /// Write to UART with TX buffer flow control to allow for intermittent
+    /// wishbone-bridge connection.
+    ///
+    /// Goal of flow control strategy is to provide non-blocking IO with
+    /// timeout limited CSR polling in order to:
+    ///  1. Avoid DoS of wishbone bus
+    ///  2. Avoid starving main control loop and COM handlers for CPU cycles
+    ///
+    /// The tradeoff for control loop responsiveness is that some debug
+    /// characters may be dropped. Timeout delay is calibrated so that, when a
+    /// wishbone-tool serial connection is established promptly after reset,
+    /// dropped characters are unlikely.
+    ///
     pub fn putc(&self, c: u8) {
+        static mut MUTED: bool = false;
         let mut uart_csr = CSR::new(HW_UART_BASE as *mut u32);
-        // Wait until TXFULL is `0`
-        while uart_csr.rf(utra::uart::TXFULL_TXFULL) != 0 {}
-        uart_csr.wfo(utra::uart::RXTX_RXTX, c as u32)
+        let tx_buffer_empty = uart_csr.rf(utra::uart::TXEMPTY_TXEMPTY) == 1;
+        if unsafe { MUTED } && !tx_buffer_empty {
+            // Looks like connection is still down... Drop this character.
+            return;
+        } else if tx_buffer_empty {
+            // Yay... looks like wishbone-bridge connection is back!
+            unsafe {
+                MUTED = false;
+            }
+        } else {
+            if uart_csr.rf(utra::uart::TXFULL_TXFULL) == 1 {
+                // Hmm... TX buffer is newly full... Watch to see if it drains...
+                for _ in 0..FLOW_CONTROL_TIMEOUT_MS {
+                    delay_ms(1);
+                    if uart_csr.rf(utra::uart::TXFULL_TXFULL) == 0 {
+                        break;
+                    }
+                }
+                if uart_csr.rf(utra::uart::TXFULL_TXFULL) == 1 {
+                    // Boo... Nope. Looks like the connection just dropped...
+                    // 1. Mute to avoid pointlessly calling delay_ms() while there is
+                    //    no active wishbone-bridge connection to drain the TX buffer
+                    // 2. Begin dropping characters, starting with this one
+                    unsafe {
+                        MUTED = true;
+                    }
+                    return;
+                }
+            }
+        }
+        // Since the flow control checks all passed, send a character
+        uart_csr.wfo(utra::uart::RXTX_RXTX, c as u32);
     }
 }
 
 #[cfg(not(feature = "debug_uart"))]
 impl Uart {
-    pub fn putc(&self, _c: u8) {
-    }
+    pub fn putc(&self, _c: u8) {}
 }
 
 use core::fmt::{Error, Write};
@@ -30,7 +108,6 @@ impl Write for Uart {
     }
 }
 
-#[macro_export]
 macro_rules! sprint
 {
 	($($args:tt)+) => ({
@@ -39,7 +116,10 @@ macro_rules! sprint
 	});
 }
 
-#[macro_export]
+// Note to people tempted to change "\r\n" to "\n" in the macros below:
+// Wishbone-tool's serial bridge expects CRLF style line termination. If you do
+// LF only, it will print your text in diagonal cascades instead of columns.
+//
 macro_rules! sprintln
 {
 	() => ({
@@ -53,3 +133,34 @@ macro_rules! sprintln
 	});
 }
 
+#[cfg(feature = "debug_uart")]
+macro_rules! log {
+    ($level:expr, $($e:expr),+) => {
+        if LOG_LEVEL <= $level {
+            sprint!($($e),+)
+        }
+    }
+}
+
+#[cfg(feature = "debug_uart")]
+macro_rules! logln {
+    ($level:expr, $($e:expr),*) => {
+        if LOG_LEVEL <= $level {
+            sprintln!($($e),*)
+        }
+    }
+}
+
+#[cfg(not(feature = "debug_uart"))]
+macro_rules! log {
+    ($_a:expr, $($_b:expr),+) => {
+        ()
+    };
+}
+
+#[cfg(not(feature = "debug_uart"))]
+macro_rules! logln {
+    ($($_a:expr),+) => {
+        ()
+    };
+}


### PR DESCRIPTION
This refactor is meant to prepare the EC codebase for adding more WF200 wifi and IP networking support.

Main goals that are hopefully achieved by these changes:
1. Resolve the previous connection reliability issues for serial debug logging with wishbone-tool
2. Prune dead code to improve readability
3. Resolve compiler warnings
4. Organize `use` declarations to improve readability
5. Move some of the SSID scanning and power management code out of the main event loop to make it easier to follow the control flow
6. Run rustfmt on the main files with WF200-related code to prepare for using rustfmt regularly when adding new features
7. Improve debug logging granularity by adding log level filtering
8. Re-work the WF200 reset code to improve its reliability
9. Re-work the WF200 SSID scan code to use it as an integration test for the other logging and refactoring changes

The commit messages have more details.

COM Bus Side Quest:
- Along the way, I encountered a problem with corruption of COM bus data being sent from the UP5K to the XC7S. It seems like the root problem had to do with timing constraints around the COM bus clock domain.
- Rebuilding betrusted_ec.py with `--seed=1` (vs default of 0) seemed to resolve the problem for now.