### PR TITLE
Switch serial debug to plain UART (no more gdb & wishbone-bridge)

### DIFF
--- a/sw/Cargo.toml
+++ b/sw/Cargo.toml
@@ -28,7 +28,4 @@ test = false
 bench = false
 
 [features]
-debug_uart = [ "wfx_rs/debug_uart", "debug/debug_uart" ]
-# default = ["debug_uart"]  # "debug_uart" to turn on uart debugging
-# note to self: when debugging, watchdog timer is automatically disabled
-default = ["debug_uart"]
+default = []

--- a/sw/debug/Cargo.toml
+++ b/sw/debug/Cargo.toml
@@ -9,5 +9,4 @@ betrusted-hal = { path = "../betrusted-hal" }
 utralib = { path = "../../utralib" }
 
 [features]
-debug_uart = []
-#default = ["debug_uart"]
+default = []

--- a/sw/debug/src/lib.rs
+++ b/sw/debug/src/lib.rs
@@ -1,24 +1,14 @@
 #![no_std]
-//! Serial debug for wishbone-bridge crossover UART.
+//! Serial debug logger.
 //!
-//! To enable serial debug printing:
-//!  1. Build and flash EC gateware with `debugonly = True`
-//!  2. In ../Cargo.toml, enable the "debug_uart" feature for this crate
-//!
+//! In the past, this used Wishbone-bridge, but now it's just a plain UART.
 
-#[cfg(feature = "debug_uart")]
 use utralib::generated::*;
-
-#[cfg(feature = "debug_uart")]
 extern crate betrusted_hal;
-
-#[cfg(feature = "debug_uart")]
 use crate::betrusted_hal::hal_time::delay_ms;
 
-/// The flow control timeout determines how long putc() waits to decide if the
-/// wishbone-bridge connection is down before dropping characters.
-#[cfg(feature = "debug_uart")]
-const FLOW_CONTROL_TIMEOUT_MS: usize = 1000;
+/// Flow control timeout limits how long putc() waits to drain a full TX buffer
+const FLOW_CONTROL_TIMEOUT_MS: usize = 5;
 
 #[derive(PartialOrd, PartialEq)]
 #[allow(dead_code)]
@@ -40,63 +30,21 @@ pub fn set_log_level(level: LL) {
 }
 
 pub struct Uart {}
-
-#[cfg(feature = "debug_uart")]
 impl Uart {
-    /// Write to UART with TX buffer flow control to allow for intermittent
-    /// wishbone-bridge connection.
-    ///
-    /// Goal of flow control strategy is to provide non-blocking IO with
-    /// timeout limited CSR polling in order to:
-    ///  1. Avoid DoS of wishbone bus
-    ///  2. Avoid starving main control loop and COM handlers for CPU cycles
-    ///
-    /// The tradeoff for control loop responsiveness is that some debug
-    /// characters may be dropped. Timeout delay is calibrated so that, when a
-    /// wishbone-tool serial connection is established promptly after reset,
-    /// dropped characters are unlikely.
-    ///
+    /// Write to UART with TX buffer flow control
     pub fn putc(&self, c: u8) {
-        static mut MUTED: bool = false;
         let mut uart_csr = CSR::new(HW_UART_BASE as *mut u32);
-        let tx_buffer_empty = uart_csr.rf(utra::uart::TXEMPTY_TXEMPTY) == 1;
-        if unsafe { MUTED } && !tx_buffer_empty {
-            // Looks like connection is still down... Drop this character.
-            return;
-        } else if tx_buffer_empty {
-            // Yay... looks like wishbone-bridge connection is back!
-            unsafe {
-                MUTED = false;
-            }
-        } else {
+        // Allow TX buffer to drain if it's full
+        for _ in 0..FLOW_CONTROL_TIMEOUT_MS {
             if uart_csr.rf(utra::uart::TXFULL_TXFULL) == 1 {
-                // Hmm... TX buffer is newly full... Watch to see if it drains...
-                for _ in 0..FLOW_CONTROL_TIMEOUT_MS {
-                    delay_ms(1);
-                    if uart_csr.rf(utra::uart::TXFULL_TXFULL) == 0 {
-                        break;
-                    }
-                }
-                if uart_csr.rf(utra::uart::TXFULL_TXFULL) == 1 {
-                    // Boo... Nope. Looks like the connection just dropped...
-                    // 1. Mute to avoid pointlessly calling delay_ms() while there is
-                    //    no active wishbone-bridge connection to drain the TX buffer
-                    // 2. Begin dropping characters, starting with this one
-                    unsafe {
-                        MUTED = true;
-                    }
-                    return;
-                }
+                delay_ms(1);
+            } else {
+                break;
             }
         }
-        // Since the flow control checks all passed, send a character
+        // Send a character
         uart_csr.wfo(utra::uart::RXTX_RXTX, c as u32);
     }
-}
-
-#[cfg(not(feature = "debug_uart"))]
-impl Uart {
-    pub fn putc(&self, _c: u8) {}
 }
 
 use core::fmt::{Error, Write};
@@ -118,10 +66,6 @@ macro_rules! sprint
 	});
 }
 
-// Note to people tempted to change "\r\n" to "\n" in the macros below:
-// Wishbone-tool's serial bridge expects CRLF style line termination. If you do
-// LF only, it will print your text in diagonal cascades instead of columns.
-//
 #[macro_export]
 macro_rules! sprintln
 {
@@ -136,7 +80,6 @@ macro_rules! sprintln
 	});
 }
 
-#[cfg(feature = "debug_uart")]
 #[macro_export]
 macro_rules! log {
     ($level:expr, $($e:expr),+) => {
@@ -146,7 +89,6 @@ macro_rules! log {
     }
 }
 
-#[cfg(feature = "debug_uart")]
 #[macro_export]
 macro_rules! logln {
     ($level:expr, $($e:expr),*) => {
@@ -154,16 +96,4 @@ macro_rules! logln {
             sprintln!($($e),*)
         }
     }
-}
-
-#[cfg(not(feature = "debug_uart"))]
-#[macro_export]
-macro_rules! log {
-    ($_a:expr, $($_b:expr),+) => {()};
-}
-
-#[cfg(not(feature = "debug_uart"))]
-#[macro_export]
-macro_rules! logln {
-    ($($_a:expr),+) => {()};
 }


### PR DESCRIPTION
This updates the serial debug logging in the EC firmware to reflect that the serial port is now a plain UART (gdb support over wishbone-bridge is gone).

Changes:
1. Simplify TX flow control to just a short delay_ms call when the TX buffer is full
2. Entirely remove the "debug_uart" feature, leaving both the debug logging calls and the watchdog timer turned on

The main consequence of the gateware change was that fancy TX flow control is no longer necessary to avoid locking up the EC event loop. With the new gateware, the glitches that debug_uart worked around appear to be no longer a problem.

Serial debug logging seems to co-exist happily with the watchdog timer and SoC sleep mode now that the wishbone-bridge is gone. Sleep and resume works fine. Serial TX during sleep mode gets dropped, but after wake, it comes back.

Quality of the serial output seems very good now. Before this change, some of the initial log messages after running `./config_up5k.sh` were getting dropped. Now it seems like all the early boot messages are coming through (tested by leaving screen connected while flashing).