### PR TITLE
Improve EC packet filter plumbing

### DIFF
--- a/sw/net/src/filter.rs
+++ b/sw/net/src/filter.rs
@@ -1,19 +1,19 @@
 /// Incoming Ethernet frames get sorted into these bins by the packet filter
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum FilterBin {
     DropNoise, // Malformed packet
     DropEType, // Unsupported Ethernet protocol (perhaps IPv6, 802.1Q VLAN, etc)
     DropDhcp, // DHCP noise (perhaps malformed options or server response out of sync with client state machine)
     DropMulti, // Multicast (likely mDNS)
-    DropProto, // Unsupported IP layer protocol (perhaps TCP)
+    DropProto, // Unsupported IP layer protocol
     DropFrag, // Unsupported packet fragment
     DropIpCk, // Bad IP header checksum
     DropUdpCk, // Bad UDP header checksum
-    ArpReq,
-    ArpReply,
+    Arp,
     Icmp,
     Dhcp,
     Udp,
+    ComFwd, // Forward to COM net bridge
 }
 
 /// FilterStats maintains diagnostic statistics on how inbound packets were filtered
@@ -26,11 +26,11 @@ pub struct FilterStats {
     pub drop_frag: u16,
     pub drop_ipck: u16,
     pub drop_udpck: u16,
-    pub arp_req: u16,
-    pub arp_reply: u16,
+    pub arp: u16,
     pub icmp: u16,
     pub dhcp: u16,
     pub udp: u16,
+    pub com_fwd: u16,
 }
 impl FilterStats {
     /// Initialize a new filter stats struct
@@ -44,11 +44,11 @@ impl FilterStats {
             drop_frag: 0,
             drop_ipck: 0,
             drop_udpck: 0,
-            arp_req: 0,
-            arp_reply: 0,
+            arp: 0,
             icmp: 0,
             dhcp: 0,
             udp: 0,
+            com_fwd: 0,
         }
     }
 
@@ -68,11 +68,11 @@ impl FilterStats {
             FilterBin::DropFrag => self.drop_frag = self.drop_frag.saturating_add(1),
             FilterBin::DropIpCk => self.drop_ipck = self.drop_ipck.saturating_add(1),
             FilterBin::DropUdpCk => self.drop_udpck = self.drop_udpck.saturating_add(1),
-            FilterBin::ArpReq => self.arp_req = self.arp_req.saturating_add(1),
-            FilterBin::ArpReply => self.arp_reply = self.arp_reply.saturating_add(1),
+            FilterBin::Arp => self.arp = self.arp.saturating_add(1),
             FilterBin::Icmp => self.icmp = self.icmp.saturating_add(1),
             FilterBin::Dhcp => self.dhcp = self.dhcp.saturating_add(1),
             FilterBin::Udp => self.udp = self.udp.saturating_add(1),
+            FilterBin::ComFwd => self.com_fwd = self.com_fwd.saturating_add(1),
         };
     }
 }

--- a/sw/src/main.rs
+++ b/sw/src/main.rs
@@ -152,7 +152,7 @@ fn stack_check() {
 
 #[entry]
 fn main() -> ! {
-    logln!(LL::Info, "\r\n====UP5K==0B");
+    logln!(LL::Info, "\r\n====UP5K==0C");
     let mut com_csr = CSR::new(HW_COM_BASE as *mut u32);
     let mut crg_csr = CSR::new(HW_CRG_BASE as *mut u32);
     let mut ticktimer_csr = CSR::new(HW_TICKTIMER_BASE as *mut u32);
@@ -258,7 +258,6 @@ fn main() -> ! {
 
     // interrupt manager for COM interface
     let mut com_int_mgr = com_bus::ComInterrupts::new();
-    let mut was_connected = false;
     let mut was_scanning = false;
     let mut tx_errs: u32 = 0;
 
@@ -294,31 +293,22 @@ fn main() -> ! {
                     CountdownStatus::Done => {
                         wifi::dhcp_clock_state_machine();
                         dhcp_oneshot.start(DHCP_POLL_MS);
-                        // Maybe this is sorta redundant with the "connected" check below?
-                        // The conditions they check for are subtly different. Point of this
-                        // match is specifically to use one-shot event notifications from
-                        // the DHCP state machine to control the WF200 ARP response
-                        // offloading feature.
+                        // Respond to one-shot connection state change event notifications from the
+                        // DHCP state machine to control ARP offloading and keep the COM net bridge
+                        // informed
                         match hal_wf200::dhcp_pop_and_ack_change_event() {
                             Some(dhcp::DhcpEvent::ChangedToBound) => {
                                 hal_wf200::arp_begin_offloading();
+                                // fire an interrupt whenever we enter connected state
+                                com_int_mgr.set_ipconf_update();
                             }
                             Some(dhcp::DhcpEvent::ChangedToHalted) => {
                                 hal_wf200::arp_stop_offloading();
+                                // fire an interrupt whenever we leave the connected state
+                                com_int_mgr.set_ipconf_update();
                             }
                             _ => (),
                         };
-
-                        // fire an interrupt whenever we enter or leave the connected state
-                        if com_net_bridge_enable {
-                            let connected = (wfx_rs::hal_wf200::get_status()
-                                == wfx_rs::hal_wf200::State::Connected)
-                                && (wfx_rs::hal_wf200::dhcp_get_state() == net::dhcp::State::Bound);
-                            if connected != was_connected {
-                                com_int_mgr.set_ipconf_update();
-                                was_connected = connected;
-                            }
-                        }
                     }
                 }
             }
@@ -956,7 +946,7 @@ fn main() -> ! {
                 }
                 if !error {
                     if com_net_bridge_enable {
-                        logln!(LL::Debug, "Sending packet");
+                        log!(LL::Debug, "T"); // Log TX of packet, but make it quick
                         match wfx_rs::hal_wf200::send_net_packet(
                             &mut txbuf_backing[..num_bytes as usize + PBUF_HEADER_SIZE],
                         ) {

--- a/sw/wfx_rs/src/hal_wf200.rs
+++ b/sw/wfx_rs/src/hal_wf200.rs
@@ -15,7 +15,7 @@ use bt_wf200_pds::PDS_DATA;
 use com_rs::serdes::{DhcpState, Ipv4Conf};
 use debug;
 use debug::{log, loghex, loghexln, logln, LL};
-use net;
+use net::{self, filter::FilterBin};
 
 // The mixed case constants here are the reason for the `allow(non_upper_case_globals)` above
 pub use wfx_bindings::{
@@ -1102,24 +1102,24 @@ fn sl_wfx_host_received_frame_callback(rx_buffer: *const sl_wfx_received_ind_t) 
     let length = body.frame_length as usize;
     let data = unsafe { &body.frame.as_slice(length + padding)[padding..] };
 
-    // com_net_bridge_enable is tied to an AT command in the EC main event loop
-    if !(unsafe { NET_STATE.com_net_bridge_enable }) || (dhcp_get_state() != dhcp::State::Bound) {
-        // run the current handler only during the DHCP unbound states, so that the DHCP happens
-        // entirely within the EC. Once this is done, pass the frames directly onto the host.
-        let _filter_bin = net::handle_frame(unsafe { &mut NET_STATE }, data);
-    } else {
-        // note: this is where you'd put in a packet filter for packets going to the SOC, if one were to be
-        // implemented. Right now, after DHCP is successful, all data is passed on.
-        //
-        // TODO: Refactor this logic with a filter that will allow the EC to complete a DHCP Renew or Rebind
-        //       without disconnecting the COM bus net bridge. (that will probably be a moderate hassle)
-        let maybe_pkt = unsafe { PACKET_BUF.get_enqueue_slice(data.len()) };
-        if let Some(pkt) = maybe_pkt {
-            for (&src, dst) in data.iter().zip(pkt.iter_mut()) {
-                *dst = src;
+    // This will give the EC's DHCP client and packet filter first dibs on the packet
+    let filter_bin = net::handle_frame(unsafe { &mut NET_STATE }, data);
+
+    // If the filter bin came back as ComFwd, that means the EC wants the packet to be
+    // forwarded up the COM bus net bridge. The com_net_bridge_enable check relates to an
+    // AT command in the EC main event loop
+    if (filter_bin == FilterBin::ComFwd) && unsafe { NET_STATE.com_net_bridge_enable } {
+        if let Some(_) = unsafe { NET_STATE.dhcp.ip } {
+            let maybe_pkt = unsafe { PACKET_BUF.get_enqueue_slice(data.len()) };
+            if let Some(pkt) = maybe_pkt {
+                log!(LL::Debug, "R"); // RX packet for COM bus
+                for (&src, dst) in data.iter().zip(pkt.iter_mut()) {
+                    *dst = src;
+                }
+            } else {
+                log!(LL::Debug, "D"); // Drop RX packet because COM bus congested
+                drop_packet();
             }
-        } else {
-            drop_packet();
         }
     }
 }


### PR DESCRIPTION
This integrates the plumbing for the old EC packet filter and the new COM bus bridge to prepare for finishing the DHCP state machine implementation.

Changes:
1. Add an EC AT command to disconnect the COM bus net bridge for testing EC packet handling without smoltcp (power up default is for the COM bus net bridge to be in the normal connected state)
2. Integrate the IP address binding notification mechanism for ARP and COM bus interrupts so both are directly tied to the connectivity change event latch output of the DHCP state machine, which is in turn connected to the WF200 link status (no more complicated if conditions in the EC event loop to compare WF200 status and DHCP state)
2. Significantly reduce debug logging output from the old packet filter code to avoid adding delays
3. Modify the packet filter so UDP port 68 packets always go to the EC DHCP client but other ICMP, UDP, and TCP packets go up the COM bus bridge to smoltcp

The main point of all this is to avoid connectivity glitches when the DHCP state machine goes through the Renew or Rebind states. The DHCP renew and rebind timers still need to be implemented, but this change should hopefully make that future change seamless from the perspective of code on the Xous side of the COM bus.